### PR TITLE
CI: Fix go coverprofile report workflow

### DIFF
--- a/.github/workflows/go-testcover-report.yaml
+++ b/.github/workflows/go-testcover-report.yaml
@@ -32,10 +32,6 @@ jobs:
           go-version: 'stable'
           cache-dependency-path: go.sum
 
-      - name: Install package dependencies
-        run:
-          sudo apt-get install -y gcc libgl1-mesa-dev xorg-dev
-
       - name: Generate reports
         run: |
           ${GITHUB_WORKSPACE}/main/hack/coverprofile.sh

--- a/hack/coverprofile.sh
+++ b/hack/coverprofile.sh
@@ -6,13 +6,12 @@ base_dir="$(dirname "${BASH_SOURCE[0]}" | xargs realpath)/.."
 
 pushd "${base_dir}" >/dev/null
 
-OUT_DIR="${base_dir}/coverprofiles"
+OUT_DIR="coverprofiles"
 
 if [ ! -d "${OUT_DIR}" ]; then
     mkdir "${OUT_DIR}"
 fi
 
-go test -coverprofile="${OUT_DIR}/cover.out" "./..."
-go tool cover -html "${OUT_DIR}/cover.out" -o "${OUT_DIR}/index.html"
+podman run -t -v "${base_dir}":/app:z ghcr.io/heathcliff26/go-fyne-ci:latest /bin/bash -c "go test -coverprofile=\"${OUT_DIR}/cover.out\" ./... && go tool cover -html \"${OUT_DIR}/cover.out\" -o \"${OUT_DIR}/index.html\""
 
 popd >/dev/null


### PR DESCRIPTION
Speed up the workflow and fix missing dependencies by using the container image instead of running directly on the runner.