### PR TITLE
Remove size struct from difficulty and use row and col directly instead

### DIFF
--- a/pkg/app/grid.go
+++ b/pkg/app/grid.go
@@ -37,7 +37,7 @@ type MinesweeperGrid struct {
 
 // Create a new grid suitable for the give difficulty
 func NewMinesweeperGrid(d minesweeper.Difficulty) *MinesweeperGrid {
-	tiles := utils.Make2D[*Tile](d.Size.Row, d.Size.Col)
+	tiles := utils.Make2D[*Tile](d.Row, d.Col)
 	grid := &MinesweeperGrid{
 		Tiles:      tiles,
 		Difficulty: d,
@@ -119,12 +119,12 @@ func (g *MinesweeperGrid) TappedTile(x, y int) {
 
 // Return the number of rows in the grid
 func (g *MinesweeperGrid) Row() int {
-	return g.Difficulty.Size.Row
+	return g.Difficulty.Row
 }
 
 // Return the number of columns in the grid
 func (g *MinesweeperGrid) Col() int {
-	return g.Difficulty.Size.Col
+	return g.Difficulty.Col
 }
 
 // Start a new game

--- a/pkg/minesweeper/difficulty.go
+++ b/pkg/minesweeper/difficulty.go
@@ -9,35 +9,35 @@ const (
 
 // Represent a difficulty setting for the Game
 type Difficulty struct {
-	Name  string
-	Size  GridSize
-	Mines int
-}
-
-type GridSize struct {
+	Name     string
 	Row, Col int
+	Mines    int
 }
 
 // Pre-defined difficulties
 var difficulties []Difficulty = []Difficulty{
 	{
 		Name:  "Classic",
-		Size:  GridSize{8, 8},
+		Row:   8,
+		Col:   8,
 		Mines: 9,
 	},
 	{
 		Name:  "Beginner",
-		Size:  GridSize{9, 9},
+		Row:   9,
+		Col:   9,
 		Mines: 10,
 	},
 	{
 		Name:  "Intermediate",
-		Size:  GridSize{16, 16},
+		Row:   16,
+		Col:   16,
 		Mines: 40,
 	},
 	{
 		Name:  "Expert",
-		Size:  GridSize{16, 30},
+		Row:   16,
+		Col:   30,
 		Mines: 99,
 	},
 }

--- a/pkg/minesweeper/game.go
+++ b/pkg/minesweeper/game.go
@@ -43,7 +43,7 @@ type Game struct {
 // Create a new game with mines seeded randomly in the map, with the exception of the given position.
 func NewGameWithSafePos(d Difficulty, p Pos) *Game {
 	g := &Game{
-		Field:      utils.Make2D[Field](d.Size.Row, d.Size.Col),
+		Field:      utils.Make2D[Field](d.Row, d.Col),
 		Difficulty: d,
 		GameOver:   false,
 		GameWon:    false,
@@ -54,15 +54,15 @@ func NewGameWithSafePos(d Difficulty, p Pos) *Game {
 		g.Field[mine.X][mine.Y].Content = Mine
 	}
 
-	for x := 0; x < d.Size.Row; x++ {
-		for y := 0; y < d.Size.Col; y++ {
+	for x := 0; x < d.Row; x++ {
+		for y := 0; y < d.Col; y++ {
 			if g.Field[x][y].Content == Mine {
 				continue
 			}
 			c := 0
 			for m := -1; m < 2; m++ {
 				for n := -1; n < 2; n++ {
-					if x+m < 0 || x+m >= d.Size.Row || y+n < 0 || y+n >= d.Size.Row {
+					if x+m < 0 || x+m >= d.Row || y+n < 0 || y+n >= d.Row {
 						continue
 					}
 					if g.Field[x+m][y+n].Content == Mine {
@@ -127,23 +127,23 @@ func (g *Game) RevealField(p Pos) {
 
 // Check if the given position is out of bounds
 func (g *Game) outOfBounds(p Pos) bool {
-	s := g.Difficulty.Size
-	return p.X < 0 || p.X > s.Row-1 || p.Y < 0 || p.Y > s.Col-1
+	d := g.Difficulty
+	return p.X < 0 || p.X > d.Row-1 || p.Y < 0 || p.Y > d.Col-1
 }
 
 // Returns the current status of the game. Only contains the knowledge a player should have.
 func (g *Game) Status() *Status {
-	size := g.Difficulty.Size
+	d := g.Difficulty
 	s := &Status{
-		Field:    utils.Make2D[Field](size.Row, size.Row),
+		Field:    utils.Make2D[Field](d.Row, d.Row),
 		GameOver: g.GameOver,
 	}
 
 	wasWon := g.GameWon
 	isWon := true
 
-	for x := 0; x < size.Row; x++ {
-		for y := 0; y < size.Col; y++ {
+	for x := 0; x < d.Row; x++ {
+		for y := 0; y < d.Col; y++ {
 			s.Field[x][y].Checked = g.Field[x][y].Checked
 			if g.Field[x][y].Checked || g.GameOver || wasWon {
 				s.Field[x][y].Content = g.Field[x][y].Content
@@ -159,7 +159,7 @@ func (g *Game) Status() *Status {
 	g.GameWon, s.GameWon = isWon, isWon
 
 	if g.GameWon != wasWon {
-		for x := 0; x < size.Row; x++ {
+		for x := 0; x < d.Row; x++ {
 			copy(s.Field[x], g.Field[x])
 		}
 	}

--- a/pkg/minesweeper/game_test.go
+++ b/pkg/minesweeper/game_test.go
@@ -8,24 +8,24 @@ import (
 
 func TestOutOfBounds(t *testing.T) {
 	g := NewGameWithSafePos(difficulties[DifficultyExpert], Pos{2, 2})
-	s := g.Difficulty.Size
+	d := g.Difficulty
 
 	assert := assert.New(t)
 
-	for x := 0; x < s.Row; x++ {
-		for y := 0; y < s.Col; y++ {
+	for x := 0; x < d.Row; x++ {
+		for y := 0; y < d.Col; y++ {
 			p := Pos{x, y}
 			assert.Falsef(g.outOfBounds(p), "%v should be within the field", p)
 
 			p.X = -1
 			assert.Truef(g.outOfBounds(p), "%v should be out of bounds", p)
-			p.X = s.Row
+			p.X = d.Row
 			assert.Truef(g.outOfBounds(p), "%v should be out of bounds", p)
 			p.X = x
 
 			p.Y = -1
 			assert.Truef(g.outOfBounds(p), "%v should be out of bounds", p)
-			p.Y = s.Col
+			p.Y = d.Col
 			assert.Truef(g.outOfBounds(p), "%v should be out of bounds", p)
 		}
 	}

--- a/pkg/minesweeper/utils.go
+++ b/pkg/minesweeper/utils.go
@@ -23,9 +23,9 @@ func CreateMines(d Difficulty, p Pos) []Pos {
 
 	mines = append(mines, p)
 	for i := 0; i < d.Mines; i++ {
-		p = RandomPos(d.Size.Row, d.Size.Col)
+		p = RandomPos(d.Row, d.Col)
 		for slices.Contains(mines, p) {
-			p = RandomPos(d.Size.Row, d.Size.Col)
+			p = RandomPos(d.Row, d.Col)
 		}
 		mines = append(mines, p)
 	}

--- a/pkg/minesweeper/utils_test.go
+++ b/pkg/minesweeper/utils_test.go
@@ -11,13 +11,14 @@ func TestCreateMines(t *testing.T) {
 	customDifficulty := Difficulty{
 		Name:  "Custom",
 		Mines: 1000,
-		Size:  GridSize{1000, 1000},
+		Row:   1000,
+		Col:   1000,
 	}
 	tMatrix = append(tMatrix, customDifficulty)
 
 	for _, d := range tMatrix {
 		t.Run(d.Name, func(t *testing.T) {
-			p := RandomPos(d.Size.Row, d.Size.Col)
+			p := RandomPos(d.Row, d.Col)
 			mines := CreateMines(d, p)
 
 			assert := assert.New(t)


### PR DESCRIPTION
The nested struct GridSize was not necessary, as it was not reused anywhere else. By removing it accessing the Row and Col values becomes easier in the code.