### PR TITLE
Renovate: Change automerge type to PR

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -20,4 +20,5 @@
   "dependencyDashboardTitle": "Renovate Dashboard 🤖",
   "suppressNotifications": ["prIgnoreNotification"],
   "postUpdateOptions": ["gomodTidy"],
+  "automergeType": "pr",
 }


### PR DESCRIPTION
The CI is not running all tests on the renovate branches, since they would be running double in case of a renovate PR.
Therefore renovate needs to raise a PR for automerge.