### PR TITLE
Add custom difficulty option

### DIFF
--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -42,7 +42,7 @@ func TestApp(t *testing.T) {
 		assert.NotEmpty(a.difficulties)
 
 		diffs := minesweeper.Difficulties()
-		assert.Equal(len(diffs), len(a.difficulties), "Should have a menu item for each difficulty")
+		assert.Equal(len(diffs), len(a.difficulties)-2, "Should have a menu item for each difficulty, as well as the custom option (+separator)")
 
 		for i, d := range diffs {
 			assert.Equal(d.Name, a.difficulties[i].Label, "Menu item label should match difficulty name")

--- a/pkg/minesweeper/difficulty.go
+++ b/pkg/minesweeper/difficulty.go
@@ -7,6 +7,13 @@ const (
 	DifficultyExpert       = iota
 )
 
+const (
+	DifficultyRowColMin         = 8
+	DifficultyRowColMax         = 99
+	DifficultyMineMin           = 9
+	DifficultyMineMaxPercentage = 0.8
+)
+
 // Represent a difficulty setting for the Game
 type Difficulty struct {
 	Name     string
@@ -47,4 +54,19 @@ func Difficulties() []Difficulty {
 	list := make([]Difficulty, len(difficulties))
 	copy(list, difficulties)
 	return list
+}
+
+func NewCustomDifficulty(mines, row, col int) (Difficulty, error) {
+	if row < DifficultyRowColMin || row > DifficultyRowColMax || col < DifficultyRowColMin || col > DifficultyRowColMax {
+		return Difficulty{}, NewErrDifficultyDimension(row, col)
+	}
+	if mines < DifficultyMineMin || float64(mines) > float64(row*col)*DifficultyMineMaxPercentage {
+		return Difficulty{}, NewErrDifficultyMineCount(mines)
+	}
+	return Difficulty{
+		Name:  "Custom",
+		Row:   row,
+		Col:   col,
+		Mines: mines,
+	}, nil
 }

--- a/pkg/minesweeper/difficulty_test.go
+++ b/pkg/minesweeper/difficulty_test.go
@@ -14,3 +14,101 @@ func TestDifficulties(t *testing.T) {
 	assert.Equal(difficulties, res)
 	assert.NotSame(difficulties, res)
 }
+
+func TestNewCustomDifficulty(t *testing.T) {
+	tMatrix := []struct {
+		Difficulty Difficulty
+		Error      error
+	}{
+		{
+			Difficulty: Difficulty{
+				Name:  "RowTooSmall",
+				Row:   DifficultyRowColMin - 1,
+				Col:   12,
+				Mines: DifficultyMineMin,
+			},
+			Error: NewErrDifficultyDimension(DifficultyRowColMin-1, 12),
+		},
+		{
+			Difficulty: Difficulty{
+				Name:  "RowTooBig",
+				Row:   DifficultyRowColMax + 1,
+				Col:   12,
+				Mines: DifficultyMineMin,
+			},
+			Error: NewErrDifficultyDimension(DifficultyRowColMax+1, 12),
+		},
+		{
+			Difficulty: Difficulty{
+				Name:  "ColTooSmall",
+				Row:   12,
+				Col:   DifficultyRowColMin - 1,
+				Mines: DifficultyMineMin,
+			},
+			Error: NewErrDifficultyDimension(12, DifficultyRowColMin-1),
+		},
+		{
+			Difficulty: Difficulty{
+				Name:  "ColTooBig",
+				Row:   12,
+				Col:   DifficultyRowColMax + 1,
+				Mines: DifficultyMineMin,
+			},
+			Error: NewErrDifficultyDimension(12, DifficultyRowColMax+1),
+		},
+		{
+			Difficulty: Difficulty{
+				Name:  "NotEnoughMines",
+				Row:   12,
+				Col:   12,
+				Mines: DifficultyMineMin - 1,
+			},
+			Error: NewErrDifficultyMineCount(DifficultyMineMin - 1),
+		},
+		{
+			Difficulty: Difficulty{
+				Name:  "TooManyMines",
+				Row:   12,
+				Col:   12,
+				Mines: 116,
+			},
+			Error: NewErrDifficultyMineCount(116),
+		},
+		{
+			Difficulty: Difficulty{
+				Name:  "LowerLimit",
+				Row:   DifficultyRowColMin,
+				Col:   DifficultyRowColMin,
+				Mines: DifficultyMineMin,
+			},
+			Error: nil,
+		},
+		{
+			Difficulty: Difficulty{
+				Name:  "UpperLimit",
+				Row:   DifficultyRowColMax,
+				Col:   DifficultyRowColMax,
+				Mines: 7840,
+			},
+			Error: nil,
+		},
+	}
+
+	for _, tCase := range tMatrix {
+		t.Run(tCase.Difficulty.Name, func(t *testing.T) {
+			d, err := NewCustomDifficulty(tCase.Difficulty.Mines, tCase.Difficulty.Row, tCase.Difficulty.Col)
+
+			assert := assert.New(t)
+
+			if tCase.Error == nil {
+				assert.Nil(err)
+				res := tCase.Difficulty
+				res.Name = "Custom"
+				assert.Equal(res, d)
+			} else {
+				assert.Empty(d)
+				assert.Equal(tCase.Error, err)
+			}
+		})
+	}
+}

--- a/pkg/minesweeper/errors.go
+++ b/pkg/minesweeper/errors.go
@@ -1,0 +1,28 @@
+package minesweeper
+
+import "fmt"
+
+type ErrDifficultyDimension struct {
+	row int
+	col int
+}
+
+func NewErrDifficultyDimension(row, col int) error {
+	return &ErrDifficultyDimension{row, col}
+}
+
+func (e *ErrDifficultyDimension) Error() string {
+	return fmt.Sprintf("Rows and Columns need to be between %d and %d, got %dx%d", DifficultyRowColMin, DifficultyRowColMax, e.row, e.col)
+}
+
+type ErrDifficultyMineCount struct {
+	mines int
+}
+
+func NewErrDifficultyMineCount(mines int) error {
+	return &ErrDifficultyMineCount{mines}
+}
+
+func (e *ErrDifficultyMineCount) Error() string {
+	return fmt.Sprintf("The number of mines need to be between %d and %.1f %% of the total number of cells, got %d", DifficultyMineMin, DifficultyMineMaxPercentage*100, e.mines)
+}


### PR DESCRIPTION
The option opens a dialog for selecting a custom difficulty. Shows error if the input is not in an accepted range.