### PR TITLE
CI: Mount cache into go-fyne-ci container to speed up operations

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
+      - name: Cache
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
+        with:
+          path: |
+            /home/runner/.cache/golangci-lint
+            /home/runner/.cache/go-build
+          key: golangci-lint
+
       - name: Run golangci-lint
         run: hack/linter.sh
 
@@ -37,6 +45,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Cache
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
+        with:
+          path: |
+            /home/runner/.cache/go-build
+          key: unit-tests
 
       - name: Run unit-tests
         run: hack/unit-tests.sh
@@ -61,6 +76,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Cache
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
+        with:
+          path: |
+            /home/runner/.cache/fyne-cross
+            /home/runner/.cache/go-build
+          key: "fyne-cross-${{ matrix.os }}-${{ matrix.arch }}"
 
       - name: Setup golang
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0

--- a/hack/linter.sh
+++ b/hack/linter.sh
@@ -4,4 +4,12 @@ set -e
 
 base_dir="$(dirname "${BASH_SOURCE[0]}" | xargs realpath)/.."
 
-podman run -t -v "${base_dir}":/app:z ghcr.io/heathcliff26/go-fyne-ci:latest golangci-lint run -v --timeout 300s
+if [ ! -d "${HOME}/.cache" ]; then
+    mkdir "${HOME}/.cache"
+fi
+
+podman run -t \
+    -v "${base_dir}":/app:z \
+    -v "${HOME}/.cache":/root/.cache  \
+    ghcr.io/heathcliff26/go-fyne-ci:latest \
+    golangci-lint run -v --timeout 300s

--- a/hack/unit-tests.sh
+++ b/hack/unit-tests.sh
@@ -4,4 +4,12 @@ set -e
 
 base_dir="$(dirname "${BASH_SOURCE[0]}" | xargs realpath)/.."
 
-podman run -t -v "${base_dir}":/app:z ghcr.io/heathcliff26/go-fyne-ci:latest go test -v ./...
+if [ ! -d "${HOME}/.cache" ]; then
+    mkdir "${HOME}/.cache"
+fi
+
+podman run -t \
+    -v "${base_dir}":/app:z \
+    -v "${HOME}/.cache":/root/.cache \
+    ghcr.io/heathcliff26/go-fyne-ci:latest \
+    go test -v ./...


### PR DESCRIPTION
Increase speed of subsequent operations by using cache. Use cache action to decrease test and build time.