### PR TITLE
Silence log output by switching to slog

### DIFF
--- a/pkg/app/grid.go
+++ b/pkg/app/grid.go
@@ -2,7 +2,7 @@ package app
 
 import (
 	"image/color"
-	"log"
+	"log/slog"
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/container"
@@ -88,10 +88,10 @@ func (g *MinesweeperGrid) TappedTile(pos minesweeper.Pos) {
 		g.Timer.Start()
 	}
 
-	log.Printf("Checking field (%d, %d)\n", pos.X, pos.Y)
+	slog.Debug("Checking field", slog.String("pos", pos.String()))
 
 	s := g.Game.CheckField(pos)
-	log.Println("Checked field, updating tiles")
+	slog.Debug("Checked field, updating tiles")
 	g.updateFromStatus(s)
 }
 
@@ -104,10 +104,10 @@ func (g *MinesweeperGrid) updateFromStatus(s *minesweeper.Status) {
 	if s.GameOver || s.GameWon {
 		switch {
 		case s.GameWon:
-			log.Println("Win")
+			slog.Info("Win")
 			g.ResetButton.SetText(ResetGameWonText)
 		case s.GameOver:
-			log.Println("Game Over")
+			slog.Info("Game Over")
 			g.ResetButton.SetText(ResetGameOverText)
 		}
 		g.Timer.Stop()
@@ -123,7 +123,7 @@ func (g *MinesweeperGrid) updateFromStatus(s *minesweeper.Status) {
 			t.UpdateContent()
 		}
 	}
-	log.Println("Finished Update")
+	slog.Debug("Finished Update")
 }
 
 // Return the number of rows in the grid
@@ -138,14 +138,14 @@ func (g *MinesweeperGrid) Col() int {
 
 // Start a new game
 func (g *MinesweeperGrid) NewGame() {
-	log.Println("Preparing for new game")
+	slog.Info("Preparing for new game")
 	g.Game = nil
 	g.Reset()
 }
 
 // Replay the current game
 func (g *MinesweeperGrid) Replay() {
-	log.Println("Preparing for replay of current game")
+	slog.Info("Preparing for replay of current game")
 	if g.Game != nil {
 		g.Game.Replay()
 	}
@@ -163,7 +163,7 @@ func (g *MinesweeperGrid) Reset() {
 	g.Timer.Reset()
 	g.ResetButton.SetText(ResetDefaultText)
 	g.ResetButton.Refresh()
-	log.Println("Reset grid")
+	slog.Debug("Reset grid")
 }
 
 // Check if the given position is out of bounds.

--- a/pkg/app/log.go
+++ b/pkg/app/log.go
@@ -1,0 +1,16 @@
+package app
+
+import (
+	"log/slog"
+	"os"
+)
+
+const logLevel = slog.LevelError
+
+func init() {
+	opts := slog.HandlerOptions{
+		Level: logLevel,
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &opts))
+	slog.SetDefault(logger)
+}

--- a/pkg/app/timer.go
+++ b/pkg/app/timer.go
@@ -2,7 +2,7 @@ package app
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 	"time"
 
 	"fyne.io/fyne/v2/canvas"
@@ -30,12 +30,12 @@ func (t *Timer) Start() {
 	ticker := time.NewTicker(time.Second)
 	t.running = true
 	go func() {
-		log.Println("Started timer")
+		slog.Debug("Started timer")
 		for {
 			select {
 			case <-t.stop:
 				ticker.Stop()
-				log.Printf("Stopped timer after %d seconds\n", t.Seconds)
+				slog.Info("Stopped timer", slog.Int("seconds", t.Seconds))
 				return
 			case <-ticker.C:
 				t.Seconds++

--- a/pkg/minesweeper/game.go
+++ b/pkg/minesweeper/game.go
@@ -1,7 +1,7 @@
 package minesweeper
 
 import (
-	"log"
+	"log/slog"
 
 	"github.com/heathcliff26/go-minesweeper/pkg/utils"
 )
@@ -112,7 +112,7 @@ func (g *LocalGame) CheckField(p Pos) *Status {
 // Recursive function to reveal all neighbouring fields that can be safely reveald.
 // Stops when a field has not exactly zero neighbouring mines
 func (g *LocalGame) RevealField(p Pos) {
-	log.Printf("Reveal tile (%d, %d), content: %d\n", p.X, p.Y, g.Field[p.X][p.Y].Content)
+	slog.Debug("Reveal field", slog.String("pos", p.String()), slog.String("content", g.Field[p.X][p.Y].Content.String()))
 
 	g.Field[p.X][p.Y].Checked = true
 
@@ -120,7 +120,7 @@ func (g *LocalGame) RevealField(p Pos) {
 		return
 	}
 
-	log.Printf("Revealing neigbhours of (%d, %d)\n", p.X, p.Y)
+	slog.Debug("Revealing fields neigbhours", slog.String("pos", p.String()))
 
 	for m := -1; m < 2; m++ {
 		for n := -1; n < 2; n++ {

--- a/pkg/minesweeper/utils.go
+++ b/pkg/minesweeper/utils.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/rand/v2"
 	"slices"
+	"strconv"
 )
 
 // Represent a position in the minefield
@@ -40,4 +41,18 @@ func CreateMines(d Difficulty, p Pos) []Pos {
 		mines = append(mines, p)
 	}
 	return mines[1:]
+}
+
+// Convert FieldContent to string for logging
+func (fc FieldContent) String() string {
+	switch {
+	case fc == Mine:
+		return "Mine"
+	case fc == Unknown:
+		return "Unknown"
+	case fc >= 0 && fc < 9:
+		return strconv.Itoa(int(fc))
+	default:
+		return fmt.Sprintf("%d is not a valid FieldContent", fc)
+	}
 }

--- a/pkg/minesweeper/utils_test.go
+++ b/pkg/minesweeper/utils_test.go
@@ -1,6 +1,7 @@
 package minesweeper
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,6 +32,59 @@ func TestCreateMines(t *testing.T) {
 
 			assert.Equal(d.Mines, len(mines))
 			assert.NotContains(mines, p)
+		})
+	}
+}
+
+type tCaseFieldContentString struct {
+	Name, Result string
+	FC           FieldContent
+}
+
+func TestFieldContentString(t *testing.T) {
+	tMatrix := []tCaseFieldContentString{
+		{
+			FC:     Mine,
+			Result: "Mine",
+		},
+		{
+			FC:     Unknown,
+			Result: "Unknown",
+		},
+		{
+			Name: "Invalid1",
+			FC:   9,
+		},
+		{
+			Name: "Invalid2",
+			FC:   -3,
+		},
+	}
+	for i := range 9 {
+		tMatrix = append(
+			tMatrix,
+			tCaseFieldContentString{
+				FC:     FieldContent(i),
+				Result: strconv.Itoa(i),
+			},
+		)
+	}
+
+	for _, tCase := range tMatrix {
+		name := tCase.Name
+		if name == "" {
+			name = tCase.Result
+		}
+
+		t.Run(name, func(t *testing.T) {
+			res := tCase.FC.String()
+
+			assert := assert.New(t)
+			if tCase.Name == "" {
+				assert.Equal(tCase.Result, res)
+			} else {
+				assert.Contains(res, "not a valid FieldContent")
+			}
 		})
 	}
 }


### PR DESCRIPTION
Log output can now be enabled when needed by changing the log level in pkg/app/log.go.

Added function to convert FieldContent to string, to enable printing in log.