### PR TITLE
Expand safe position to safe area during game creation

### DIFF
--- a/pkg/app/grid.go
+++ b/pkg/app/grid.go
@@ -82,7 +82,7 @@ func (g *MinesweeperGrid) GetCanvasObject() fyne.CanvasObject {
 // Starts a new game when no game is currently running.
 func (g *MinesweeperGrid) TappedTile(pos minesweeper.Pos) {
 	if g.Game == nil {
-		g.Game = minesweeper.NewGameWithSafePos(g.Difficulty, pos)
+		g.Game = minesweeper.NewGameWithSafeArea(g.Difficulty, pos)
 	}
 	if !g.Timer.Running() {
 		g.Timer.Start()

--- a/pkg/minesweeper/game.go
+++ b/pkg/minesweeper/game.go
@@ -77,11 +77,10 @@ func blankGame(d Difficulty) *LocalGame {
 	}
 }
 
-// Create a new game with mines seeded randomly in the map, with the exception of the given position.
-func NewGameWithSafePos(d Difficulty, p Pos) *LocalGame {
+// Create a new game with the mines in the given positions
+func newGame(d Difficulty, mines []Pos) *LocalGame {
 	g := blankGame(d)
 
-	mines := CreateMines(d, p)
 	for _, mine := range mines {
 		g.Field[mine.X][mine.Y].Content = Mine
 	}
@@ -89,6 +88,29 @@ func NewGameWithSafePos(d Difficulty, p Pos) *LocalGame {
 	g.calculateFieldContent()
 
 	return g
+}
+
+// Create a new game with mines seeded randomly in the map, with the exception of the given position.
+func NewGameWithSafePos(d Difficulty, p Pos) *LocalGame {
+	mines := CreateMines(d, []Pos{p})
+
+	return newGame(d, mines)
+}
+
+// Create a new game with mines seeded randomly in the map, with the exception of a 3x3 area around the given position.
+func NewGameWithSafeArea(d Difficulty, p Pos) *LocalGame {
+	area := make([]Pos, 0, 9)
+	for x := -1; x < 2; x++ {
+		for y := -1; y < 2; y++ {
+			p := NewPos(p.X+x, p.Y+y)
+			if !OutOfBounds(p, d) {
+				area = append(area, p)
+			}
+		}
+	}
+	mines := CreateMines(d, area)
+
+	return newGame(d, mines)
 }
 
 // Check a given field and recursevly reveal all neighboring fields that should be revield.
@@ -141,8 +163,7 @@ func (g *LocalGame) RevealField(p Pos) {
 
 // Check if the given position is out of bounds
 func (g *LocalGame) OutOfBounds(p Pos) bool {
-	d := g.Difficulty
-	return p.X < 0 || p.X > d.Row-1 || p.Y < 0 || p.Y > d.Col-1
+	return OutOfBounds(p, g.Difficulty)
 }
 
 // Returns the current status of the game. Only contains the knowledge a player should have.

--- a/pkg/minesweeper/game_test.go
+++ b/pkg/minesweeper/game_test.go
@@ -43,6 +43,46 @@ func TestNewGameWithSafePos(t *testing.T) {
 	}
 }
 
+func TestNewGameWithSafeArea(t *testing.T) {
+	tMatrix := Difficulties()
+	tMatrix = append(tMatrix, Difficulty{
+		Name:  "InvertedExpert",
+		Row:   30,
+		Col:   16,
+		Mines: 99,
+	})
+	p := NewPos(1, 1)
+
+	for _, d := range tMatrix {
+		t.Run(d.Name, func(t *testing.T) {
+			g := NewGameWithSafeArea(d, p)
+
+			assert := assert.New(t)
+
+			assert.Equal(d.Row, len(g.Field), "Should have the given number of rows")
+			assert.Equal(d.Col, len(g.Field[0]), "Should have the given number of columns")
+			assert.Equal(d, g.Difficulty, "Should have the given difficulty")
+			assert.False(g.GameOver, "Should not be Game Over")
+			assert.False(g.GameWon, "Game should not be won")
+			for x := -1; x < 2; x++ {
+				for y := -1; y < 2; y++ {
+					assert.NotEqualf(Mine, g.Field[p.X+x][p.Y+y].Content, "Safe area should not be a mine, pos=(%d, %d)", p.X+x, p.Y+y)
+				}
+			}
+
+			mines := 0
+			g.walkField(func(x, y int) {
+				if g.Field[x][y].Content == Mine {
+					mines++
+				} else {
+					assert.Equalf(g.countNearbyMines(NewPos(x, y)), int(g.Field[x][y].Content), "(%d, %d) should have the given number of neighboring mines", x, y)
+				}
+			})
+			assert.Equal(d.Mines, mines, "Should have the given number of mines")
+		})
+	}
+}
+
 func TestCheckField(t *testing.T) {
 	minefield := [][]FieldContent{
 		{Mine, 2, Mine, 1, 0, 0, 0, 0},

--- a/pkg/minesweeper/utils.go
+++ b/pkg/minesweeper/utils.go
@@ -28,11 +28,12 @@ func (p Pos) String() string {
 }
 
 // Randomly create mines for the given difficulty.
-// Does not create a mine on the given position.
-func CreateMines(d Difficulty, p Pos) []Pos {
-	mines := make([]Pos, 0, d.Mines+1)
+// Does not create a mine on the given positions.
+func CreateMines(d Difficulty, safe []Pos) []Pos {
+	var p Pos
+	mines := make([]Pos, 0, d.Mines+len(safe))
 
-	mines = append(mines, p)
+	mines = append(mines, safe...)
 	for i := 0; i < d.Mines; i++ {
 		p = RandomPos(d.Row, d.Col)
 		for slices.Contains(mines, p) {
@@ -40,7 +41,7 @@ func CreateMines(d Difficulty, p Pos) []Pos {
 		}
 		mines = append(mines, p)
 	}
-	return mines[1:]
+	return mines[len(safe):]
 }
 
 // Convert FieldContent to string for logging
@@ -55,4 +56,9 @@ func (fc FieldContent) String() string {
 	default:
 		return fmt.Sprintf("%d is not a valid FieldContent", fc)
 	}
+}
+
+// Check if a position is out of bounds on the given difficulty
+func OutOfBounds(p Pos, d Difficulty) bool {
+	return p.X < 0 || p.X > d.Row-1 || p.Y < 0 || p.Y > d.Col-1
 }

--- a/pkg/minesweeper/utils_test.go
+++ b/pkg/minesweeper/utils_test.go
@@ -26,7 +26,7 @@ func TestCreateMines(t *testing.T) {
 	for _, d := range tMatrix {
 		t.Run(d.Name, func(t *testing.T) {
 			p := RandomPos(d.Row, d.Col)
-			mines := CreateMines(d, p)
+			mines := CreateMines(d, []Pos{p})
 
 			assert := assert.New(t)
 


### PR DESCRIPTION
When creating a new game, expand the safe position to also include the immediate in a 3x3 field around the position.
This ensures that the first click of a new game is always to a blank tile, giving the player a better start into the game.