### PR TITLE
Improve performance of assisted mode by caching last result

### DIFF
--- a/pkg/app/grid.go
+++ b/pkg/app/grid.go
@@ -118,12 +118,12 @@ func (g *MinesweeperGrid) updateFromStatus(s *minesweeper.Status) {
 		return
 	}
 
-	if s.GameOver || s.GameWon {
+	if s.GameOver() || s.GameWon() {
 		switch {
-		case s.GameWon:
+		case s.GameWon():
 			slog.Info("Win")
 			g.ResetButton.SetText(ResetGameWonText)
-		case s.GameOver:
+		case s.GameOver():
 			slog.Info("Game Over")
 			g.ResetButton.SetText(ResetGameOverText)
 		}
@@ -208,7 +208,7 @@ func (g *MinesweeperGrid) Hint() bool {
 		return false
 	}
 	s := g.Game.Status()
-	if s.GameOver || s.GameWon {
+	if s.GameOver() || s.GameWon() {
 		return false
 	}
 

--- a/pkg/app/grid.go
+++ b/pkg/app/grid.go
@@ -148,7 +148,7 @@ func (g *MinesweeperGrid) updateFromStatus(s *minesweeper.Status) {
 			if s.Field[x][y].Content == minesweeper.Unknown {
 				continue
 			}
-			t.Field = &s.Field[x][y]
+			t.Field = s.Field[x][y]
 			t.UpdateContent()
 		}
 	}

--- a/pkg/app/tile.go
+++ b/pkg/app/tile.go
@@ -64,7 +64,7 @@ type Tile struct {
 	icon       *widget.Icon
 
 	Pos     minesweeper.Pos
-	Field   *minesweeper.Field
+	Field   minesweeper.Field
 	grid    *MinesweeperGrid
 	Flagged bool
 	Marker  HelpMarking
@@ -74,7 +74,7 @@ type Tile struct {
 func NewTile(x, y int, grid *MinesweeperGrid) *Tile {
 	t := &Tile{
 		Pos: minesweeper.NewPos(x, y),
-		Field: &minesweeper.Field{
+		Field: minesweeper.Field{
 			Checked: false,
 			Content: minesweeper.Unknown,
 		},

--- a/pkg/app/tile_test.go
+++ b/pkg/app/tile_test.go
@@ -20,7 +20,7 @@ func TestNewTile(t *testing.T) {
 
 		assert.Equal(g, tile.grid)
 
-		f := &minesweeper.Field{
+		f := minesweeper.Field{
 			Checked: false,
 			Content: minesweeper.Unknown,
 		}

--- a/pkg/app/tile_test.go
+++ b/pkg/app/tile_test.go
@@ -160,8 +160,8 @@ func TestDoubleTapped(t *testing.T) {
 
 		tile.DoubleTapped(nil)
 
-		assert.False(g.Game.Status().GameOver, "Game should not be lost")
-		assert.True(g.Game.Status().GameWon, "Game should be won")
+		assert.False(g.Game.Status().GameOver(), "Game should not be lost")
+		assert.True(g.Game.Status().GameWon(), "Game should be won")
 		assert.False(g.Tiles[0][0].Field.Checked, "Flagged field should not be checked")
 
 		for x := 0; x < 2; x++ {

--- a/pkg/minesweeper/game.go
+++ b/pkg/minesweeper/game.go
@@ -170,8 +170,8 @@ func (g *LocalGame) UpdateStatus() {
 	d := g.Difficulty
 	s := &Status{
 		Field:    utils.Make2D[Field](d.Row, d.Col),
-		GameOver: g.Lost(),
-		GameWon:  g.Won(),
+		gameOver: g.Lost(),
+		gameWon:  g.Won(),
 	}
 
 	wasWon := g.Won()
@@ -190,7 +190,7 @@ func (g *LocalGame) UpdateStatus() {
 	})
 
 	if !wasWon && isWon {
-		g.GameWon, s.GameWon = isWon, isWon
+		g.GameWon, s.gameWon = isWon, isWon
 		for x := 0; x < d.Row; x++ {
 			copy(s.Field[x], g.Field[x])
 		}

--- a/pkg/minesweeper/game_test.go
+++ b/pkg/minesweeper/game_test.go
@@ -346,10 +346,10 @@ func TestDetectVictory(t *testing.T) {
 	g.UpdateStatus()
 
 	assert.True(g.GameWon)
-	assert.True(g.status.GameWon)
+	assert.True(g.status.GameWon())
 
 	assert.False(g.GameOver)
-	assert.False(g.status.GameOver)
+	assert.False(g.status.GameOver())
 }
 
 func TestReplay(t *testing.T) {

--- a/pkg/minesweeper/game_test.go
+++ b/pkg/minesweeper/game_test.go
@@ -326,6 +326,7 @@ func TestStatus(t *testing.T) {
 			})
 
 			assert.Same(g.status, g.Status())
+			assert.False(g.status.actionsUpdated)
 		})
 	}
 }

--- a/pkg/minesweeper/status.go
+++ b/pkg/minesweeper/status.go
@@ -23,14 +23,17 @@ type Actions struct {
 	SafePos []Pos
 }
 
+// Returns if the game is lost
 func (s *Status) GameOver() bool {
 	return s.gameOver
 }
 
+// Returns if the game is won
 func (s *Status) GameWon() bool {
 	return s.gameWon
 }
 
+// Returns the position of all obvious mines
 func (s *Status) ObviousMines() []Pos {
 	if s.actions.Mines == nil {
 		s.createActions()
@@ -38,6 +41,7 @@ func (s *Status) ObviousMines() []Pos {
 	return s.actions.Mines
 }
 
+// Returns the position of all obvious safe positions
 func (s *Status) ObviousSafePos() []Pos {
 	if s.actions.SafePos == nil {
 		s.createActions()
@@ -45,6 +49,7 @@ func (s *Status) ObviousSafePos() []Pos {
 	return s.actions.SafePos
 }
 
+// Calculate the next actions based on the current status
 func (s *Status) createActions() {
 	s.actions = Actions{
 		Mines:   make([]Pos, 0, 10),

--- a/pkg/minesweeper/status.go
+++ b/pkg/minesweeper/status.go
@@ -12,8 +12,8 @@ import (
 // It is safe to write to Status, as it is merely a copy.
 type Status struct {
 	Field    [][]Field
-	GameOver bool
-	GameWon  bool
+	gameOver bool
+	gameWon  bool
 
 	actions Actions
 }
@@ -21,6 +21,14 @@ type Status struct {
 type Actions struct {
 	Mines   []Pos
 	SafePos []Pos
+}
+
+func (s *Status) GameOver() bool {
+	return s.gameOver
+}
+
+func (s *Status) GameWon() bool {
+	return s.gameWon
 }
 
 func (s *Status) ObviousMines() []Pos {
@@ -42,7 +50,8 @@ func (s *Status) createActions() {
 		Mines:   make([]Pos, 0, 10),
 		SafePos: make([]Pos, 0, 10),
 	}
-	if len(s.Field) == 0 || s.GameOver || s.GameWon {
+
+	if len(s.Field) == 0 || s.GameOver() || s.GameWon() {
 		return
 	}
 

--- a/pkg/minesweeper/status_test.go
+++ b/pkg/minesweeper/status_test.go
@@ -98,14 +98,14 @@ func TestCreateActionsEarlyReturn(t *testing.T) {
 			Name: "FieldGameOver",
 			Status: Status{
 				Field:    utils.Make2D[Field](1, 1),
-				GameOver: true,
+				gameOver: true,
 			},
 		},
 		{
 			Name: "FieldGameWon",
 			Status: Status{
 				Field:   utils.Make2D[Field](1, 1),
-				GameWon: true,
+				gameWon: true,
 			},
 		},
 	}

--- a/pkg/minesweeper/status_test.go
+++ b/pkg/minesweeper/status_test.go
@@ -40,7 +40,14 @@ func TestAssistedMode(t *testing.T) {
 
 				fail := false
 
+				if !assert.False(s.actionsUpdated, "Status should need update for actions") {
+					fail = true
+				}
+
 				if !assert.ElementsMatch(step.Mines, s.ObviousMines(), "Mines should match") {
+					fail = true
+				}
+				if !assert.True(s.actionsUpdated, "Status should no longer need update for actions") {
 					fail = true
 				}
 				if !assert.Equal(len(step.Mines), len(s.actions.Mines), "Should have the same amount of mines") {
@@ -53,8 +60,9 @@ func TestAssistedMode(t *testing.T) {
 					fail = true
 				}
 
+				s.actionsUpdated = false
 				s.actions.SafePos = nil
-				if !assert.ElementsMatch(step.SafePos, s.ObviousSafePos(), "Safe positions should match") {
+				if !assert.ElementsMatch(step.SafePos, s.ObviousSafePos(), "Safe positions should still match") {
 					fail = true
 				}
 
@@ -77,7 +85,7 @@ func TestAssistedMode(t *testing.T) {
 	}
 }
 
-func TestCreateActionsEarlyReturn(t *testing.T) {
+func TestUpdateActionsEarlyReturn(t *testing.T) {
 	tMatrix := []struct {
 		Name   string
 		Status Status
@@ -114,10 +122,10 @@ func TestCreateActionsEarlyReturn(t *testing.T) {
 		t.Run(tCase.Name, func(t *testing.T) {
 			assert := assert.New(t)
 
-			tCase.Status.createActions()
+			tCase.Status.updateActions()
 
-			assert.NotNil(tCase.Status.actions.Mines, "Mines should not be nil")
-			assert.NotNil(tCase.Status.actions.SafePos, "SafePos should not be nil")
+			assert.Nil(tCase.Status.actions.Mines, "Mines should not be nil")
+			assert.Nil(tCase.Status.actions.SafePos, "SafePos should not be nil")
 			assert.Empty(tCase.Status.actions.Mines, "Mines should be empty")
 			assert.Empty(tCase.Status.actions.SafePos, "SafePos should be empty")
 		})

--- a/tests/performance/main.go
+++ b/tests/performance/main.go
@@ -155,7 +155,7 @@ func measureAssistedMode(res chan time.Duration) {
 		s := game.CheckField(pos)
 		s.ObviousMines()
 		s.ObviousSafePos()
-		if s.GameOver || s.GameWon {
+		if s.GameOver() || s.GameWon() {
 			fmt.Println("Something unexpected happened, the game finished")
 		}
 	}


### PR DESCRIPTION
Save on iterations by keeping the old mines found and only pruning safe
positions.
Do not create a new status after every game update.

Additional updates:
minesweeper/status: Add comments to functions
minesweeper/status: Make gameOver and gameWon private
