### PR TITLE
app/timer: Ensure a single timer is only running once

### DIFF
--- a/pkg/app/timer.go
+++ b/pkg/app/timer.go
@@ -29,12 +29,12 @@ func NewTimer() *Timer {
 
 // Start the timer, runs concurrently
 func (t *Timer) Start() {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
 	if t.running {
 		return
 	}
-
-	t.lock.Lock()
-	defer t.lock.Unlock()
 
 	ticker := time.NewTicker(time.Second)
 	t.running = true

--- a/pkg/app/timer_test.go
+++ b/pkg/app/timer_test.go
@@ -33,4 +33,14 @@ func TestTimer(t *testing.T) {
 	assert.False(timer.running)
 	assert.Equal(0, timer.Seconds)
 	assert.Equal("0000", timer.Label.Text)
+
+	timer.Start()
+	assert.True(timer.running)
+	timer.Start()
+	assert.True(timer.running)
+
+	time.Sleep(10 * time.Second)
+	timer.Stop()
+
+	assert.Equal(10, timer.Seconds)
 }


### PR DESCRIPTION
Do not allow multiple calls to Start() for a single timer instance.