### PR TITLE
CI: Use make in scripts instead of full command

### DIFF
--- a/hack/linter.sh
+++ b/hack/linter.sh
@@ -12,4 +12,4 @@ podman run -t \
     -v "${base_dir}":/app:z \
     -v "${HOME}/.cache":/root/.cache  \
     ghcr.io/heathcliff26/go-fyne-ci:latest \
-    golangci-lint run -v --timeout 300s
+    make lint

--- a/hack/unit-tests.sh
+++ b/hack/unit-tests.sh
@@ -12,4 +12,4 @@ podman run -t \
     -v "${base_dir}":/app:z \
     -v "${HOME}/.cache":/root/.cache \
     ghcr.io/heathcliff26/go-fyne-ci:latest \
-    go test -v -race -timeout 10m ./...
+    make test


### PR DESCRIPTION
Replace commands inside ci-container with equivalent make call.