### PR TITLE
app/grid: Fix panic when asking for hint on game loaded from a savegame

### DIFF
--- a/pkg/app/grid.go
+++ b/pkg/app/grid.go
@@ -259,7 +259,7 @@ func (g *MinesweeperGrid) Hint() bool {
 		return false
 	}
 	s := g.Game.Status()
-	if s.GameOver() || s.GameWon() {
+	if s == nil || s.GameOver() || s.GameWon() {
 		return false
 	}
 

--- a/pkg/app/grid_test.go
+++ b/pkg/app/grid_test.go
@@ -234,6 +234,16 @@ func TestHint(t *testing.T) {
 		g := NewMinesweeperGrid(DEFAULT_DIFFICULTY, false)
 		assert.False(t, g.Hint(), "Should not give hint when game is nil")
 	})
+	t.Run("StatusNil", func(t *testing.T) {
+		assert := assert.New(t)
+
+		g, err := createGridFromSave("testdata/hint.sav", false)
+		if !assert.Nil(err, "Should load savegame") {
+			t.Fatal(err)
+		}
+
+		assert.False(g.Hint(), "Should not be able to display hint on game without status")
+	})
 	t.Run("GameOver", func(t *testing.T) {
 		assert := assert.New(t)
 


### PR DESCRIPTION
Fix panic when running hint on a new game with no revealed tiles.