### PR TITLE
app/autosolve: Fix delay when running multiple autosolve after another

### DIFF
--- a/pkg/app/grid.go
+++ b/pkg/app/grid.go
@@ -393,8 +393,10 @@ func (g *MinesweeperGrid) Autosolve(delay time.Duration) bool {
 
 		for _, mine := range s.ObviousMines() {
 			tile := g.Tiles[mine.X][mine.Y]
-			tile.Flag(true)
-			time.Sleep(autosolveFlagMineDelay)
+			if !tile.Flagged() {
+				tile.Flag(true)
+				time.Sleep(autosolveFlagMineDelay)
+			}
 		}
 	}
 


### PR DESCRIPTION
Fix a delay in flagging mines when running consecutive autosolve operations.