### PR TITLE
Fix UI freezing after displaying hint

### DIFF
--- a/pkg/app/grid.go
+++ b/pkg/app/grid.go
@@ -318,6 +318,7 @@ func (g *MinesweeperGrid) Hint() bool {
 	g.lGame.Lock()
 
 	if g.Game == nil {
+		g.lGame.Unlock()
 		return false
 	}
 	s := g.Game.Status()


### PR DESCRIPTION
Fix a freeze of the grid when trying to display a hint when no game is running.