### PR TITLE
CI: Run Renovate less frequently

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -13,7 +13,7 @@ on:
         default: debug
         required: false
   schedule:
-    - cron: "10 * * * 5"
+    - cron: "10 * 1 * *"
   push:
     branches: ["main"]
     paths:


### PR DESCRIPTION
There is no need to have weekly updates. Better to bundle it into a single day of the month.