### PR TITLE
Add metainfo for building flatpaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,9 @@ dependencies:
 generate:
 	go generate ./...
 
+lint-metainfo:
+	flatpak run --command=flatpak-builder-lint org.flatpak.Builder appstream io.github.heathcliff26.go-minesweeper.metainfo.xml
+
 .PHONY: \
 	default \
 	build \
@@ -37,4 +40,5 @@ generate:
 	assets \
 	dependencies \
 	generate \
+	lint-metainfo \
 	$(NULL)

--- a/io.github.heathcliff26.go-minesweeper.metainfo.xml
+++ b/io.github.heathcliff26.go-minesweeper.metainfo.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+    <id>io.github.heathcliff26.go-minesweeper</id>
+
+    <name>go-minesweeper</name>
+    <summary>A minesweeper implementation in golang</summary>
+
+    <metadata_license>MIT</metadata_license>
+    <project_license>Artistic-2.0</project_license>
+
+    <description>
+        <p>
+            This is an implementation of minesweeper in golang, made with the ui framework fyne.io.
+        </p>
+        <p>
+            I mainly created it because i was bored and wanted to create a gui app.
+        </p>
+    </description>
+
+    <url type="homepage">https://github.com/heathcliff26/go-minesweeper</url>
+    <developer id="io.github.heathcliff26">
+        <name>Heathcliff</name>
+    </developer>
+
+    <content_rating type="oars-1.1" />
+
+    <launchable type="desktop-id">io.github.heathcliff26.go-minesweeper.desktop</launchable>
+
+    <screenshots>
+        <screenshot type="default">
+            <image type="source">https://raw.githubusercontent.com/heathcliff26/go-minesweeper/bbca5ab55595673070bb05f32595f8978c0970a6/img/screenshots/screenshot-difficulty-advanced.png</image>
+        </screenshot>
+        <screenshot>
+            <image type="source">https://raw.githubusercontent.com/heathcliff26/go-minesweeper/bbca5ab55595673070bb05f32595f8978c0970a6/img/screenshots/screenshot-difficulty-beginner.png</image>
+        </screenshot>
+        <screenshot>
+            <image type="source">https://raw.githubusercontent.com/heathcliff26/go-minesweeper/bbca5ab55595673070bb05f32595f8978c0970a6/img/screenshots/screenshot-difficulty-expert.png</image>
+        </screenshot>
+    </screenshots>
+
+    <releases>
+        <release version="v0.5.5" date="2024-11-01" type="stable">
+            <description>
+                <p>Dependency bumps</p>
+            </description>
+            <url type="details">https://github.com/heathcliff26/go-minesweeper/releases/tag/v0.5.5</url>
+        </release>
+    </releases>
+
+</component>


### PR DESCRIPTION
Add a metainfo.xml to include in flatpaks.
Required for hosting on flathub.