### PR TITLE
app: Add automatic saving of selected options between sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ coverprofiles/
 
 # Test save files
 /*.sav
+/settings.yaml
+/saves

--- a/hack/clean.sh
+++ b/hack/clean.sh
@@ -4,7 +4,7 @@ set -e
 
 base_dir="$(dirname "${BASH_SOURCE[0]}" | xargs realpath)/.."
 
-folders=("fyne-cross" "bin" "coverprofiles" "dist")
+folders=("fyne-cross" "bin" "coverprofiles" "dist" "saves")
 
 for folder in "${folders[@]}"; do
     if ! [ -e "${base_dir}/${folder}" ]; then
@@ -13,3 +13,8 @@ for folder in "${folders[@]}"; do
     echo "Removing ${folder}"
     rm -rf "${base_dir:-.}/${folder}"
 done
+
+if [ -e "${base_dir}/settings.yaml" ]; then
+    echo "Removing settings.yaml"
+    rm "${base_dir}/settings.yaml"
+fi

--- a/pkg/app/grid_test.go
+++ b/pkg/app/grid_test.go
@@ -17,13 +17,13 @@ type assistedModeTestConfig struct {
 }
 
 func TestNewGrid(t *testing.T) {
-	g := NewMinesweeperGrid(DEFAULT_DIFFICULTY, true)
+	g := NewMinesweeperGrid(minesweeper.Difficulties()[DEFAULT_DIFFICULTY], true)
 
 	assert := assert.New(t)
 
 	assert.Equal(g.Row(), len(g.Tiles))
 	assert.Equal(g.Col(), len(g.Tiles[0]))
-	assert.Equal(DEFAULT_DIFFICULTY, g.Difficulty)
+	assert.Equal(minesweeper.Difficulties()[DEFAULT_DIFFICULTY], g.Difficulty)
 	assert.Nil(g.Game)
 	assert.True(g.AssistedMode)
 	assert.Equal(DEFAULT_GAME_ALGORITHM, g.GameAlgorithm)
@@ -33,7 +33,7 @@ func TestNewGrid(t *testing.T) {
 }
 
 func TestTappedTile(t *testing.T) {
-	g := NewMinesweeperGrid(DEFAULT_DIFFICULTY, false)
+	g := NewMinesweeperGrid(minesweeper.Difficulties()[DEFAULT_DIFFICULTY], false)
 	for _, row := range g.Tiles {
 		for _, tile := range row {
 			tile.CreateRenderer()
@@ -50,7 +50,7 @@ func TestTappedTile(t *testing.T) {
 }
 
 func TestGameAlgorithm(t *testing.T) {
-	g := NewMinesweeperGrid(DEFAULT_DIFFICULTY, false)
+	g := NewMinesweeperGrid(minesweeper.Difficulties()[DEFAULT_DIFFICULTY], false)
 	for _, row := range g.Tiles {
 		for _, tile := range row {
 			tile.CreateRenderer()
@@ -75,7 +75,7 @@ func TestGameAlgorithm(t *testing.T) {
 }
 
 func TestNewGame(t *testing.T) {
-	g := NewMinesweeperGrid(DEFAULT_DIFFICULTY, false)
+	g := NewMinesweeperGrid(minesweeper.Difficulties()[DEFAULT_DIFFICULTY], false)
 	for _, row := range g.Tiles {
 		for _, tile := range row {
 			tile.CreateRenderer()
@@ -100,7 +100,7 @@ func TestNewGame(t *testing.T) {
 }
 
 func TestReplay(t *testing.T) {
-	g := NewMinesweeperGrid(DEFAULT_DIFFICULTY, false)
+	g := NewMinesweeperGrid(minesweeper.Difficulties()[DEFAULT_DIFFICULTY], false)
 	for _, row := range g.Tiles {
 		for _, tile := range row {
 			tile.CreateRenderer()
@@ -130,7 +130,7 @@ func TestUpdateFromStatus(t *testing.T) {
 	t.Run("NilPointer", func(t *testing.T) {
 		t.Parallel()
 
-		g := NewMinesweeperGrid(DEFAULT_DIFFICULTY, false)
+		g := NewMinesweeperGrid(minesweeper.Difficulties()[DEFAULT_DIFFICULTY], false)
 		// Should not panic
 		g.updateFromStatus(nil)
 	})
@@ -138,7 +138,7 @@ func TestUpdateFromStatus(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
 
-		g := NewMinesweeperGrid(DEFAULT_DIFFICULTY, false)
+		g := NewMinesweeperGrid(minesweeper.Difficulties()[DEFAULT_DIFFICULTY], false)
 		for _, row := range g.Tiles {
 			for _, tile := range row {
 				tile.CreateRenderer()
@@ -247,7 +247,7 @@ func TestAssistedMode(t *testing.T) {
 
 func TestHint(t *testing.T) {
 	t.Run("GameNil", func(t *testing.T) {
-		g := NewMinesweeperGrid(DEFAULT_DIFFICULTY, false)
+		g := NewMinesweeperGrid(minesweeper.Difficulties()[DEFAULT_DIFFICULTY], false)
 		assert.False(t, g.Hint(), "Should not give hint when game is nil")
 	})
 	t.Run("StatusNil", func(t *testing.T) {
@@ -332,14 +332,14 @@ func TestAutosolve(t *testing.T) {
 	t.Run("GameNil", func(t *testing.T) {
 		t.Parallel()
 
-		g := NewMinesweeperGrid(DEFAULT_DIFFICULTY, false)
+		g := NewMinesweeperGrid(minesweeper.Difficulties()[DEFAULT_DIFFICULTY], false)
 
 		assert.False(t, g.Autosolve(0), "Should not run autosolve")
 	})
 	t.Run("StatusNil", func(t *testing.T) {
 		t.Parallel()
 
-		g := NewMinesweeperGrid(DEFAULT_DIFFICULTY, false)
+		g := NewMinesweeperGrid(minesweeper.Difficulties()[DEFAULT_DIFFICULTY], false)
 		for _, row := range g.Tiles {
 			for _, tile := range row {
 				tile.CreateRenderer()
@@ -352,7 +352,7 @@ func TestAutosolve(t *testing.T) {
 	t.Run("GameWon", func(t *testing.T) {
 		t.Parallel()
 
-		g := NewMinesweeperGrid(DEFAULT_DIFFICULTY, false)
+		g := NewMinesweeperGrid(minesweeper.Difficulties()[DEFAULT_DIFFICULTY], false)
 		for _, row := range g.Tiles {
 			for _, tile := range row {
 				tile.CreateRenderer()
@@ -369,7 +369,7 @@ func TestAutosolve(t *testing.T) {
 	t.Run("GameOver", func(t *testing.T) {
 		t.Parallel()
 
-		g := NewMinesweeperGrid(DEFAULT_DIFFICULTY, false)
+		g := NewMinesweeperGrid(minesweeper.Difficulties()[DEFAULT_DIFFICULTY], false)
 		for _, row := range g.Tiles {
 			for _, tile := range row {
 				tile.CreateRenderer()
@@ -388,7 +388,7 @@ func TestAutosolve(t *testing.T) {
 		assert := assert.New(t)
 
 		for _, value := range []bool{true, false} {
-			g := NewMinesweeperGrid(DEFAULT_DIFFICULTY, false)
+			g := NewMinesweeperGrid(minesweeper.Difficulties()[DEFAULT_DIFFICULTY], false)
 			for _, row := range g.Tiles {
 				for _, tile := range row {
 					tile.CreateRenderer()

--- a/pkg/app/locations/locations.go
+++ b/pkg/app/locations/locations.go
@@ -1,14 +1,49 @@
 package locations
 
-import "os"
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+)
 
 const appName = "go-minesweeper"
 
+const settingsFilename = "settings.yaml"
+
 var saveFolder = ""
+
+var settingsFile = ""
 
 func SaveFolder() (string, error) {
 	if saveFolder != "" {
+		return saveFolder, nil
+	}
+
+	var err error
+	saveFolder, err = loadSaveFolderLocation()
+	if err == nil {
 		return saveFolder, os.MkdirAll(saveFolder, 0755)
 	}
+	slog.Error("Failed to load save folder location, falling back to current directory", "err", err)
+
 	return os.Getwd()
+}
+
+func SettingsFile() (string, error) {
+	if settingsFile != "" {
+		return settingsFile, nil
+	}
+
+	var err error
+	settingsFile, err = loadSettingsFileLocation()
+	if err == nil {
+		return settingsFile, os.MkdirAll(filepath.Dir(settingsFile), 0755)
+	}
+	slog.Error("Failed to load settings.yaml location, falling back to current directory", "err", err)
+
+	pwd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(pwd, settingsFilename), nil
 }

--- a/pkg/app/locations/locations_linux.go
+++ b/pkg/app/locations/locations_linux.go
@@ -3,27 +3,32 @@
 package locations
 
 import (
-	"log/slog"
 	"os"
 	"path/filepath"
 )
 
-func init() {
-	loadSaveFolderLocation()
-}
-
-func loadSaveFolderLocation() {
+func loadSaveFolderLocation() (string, error) {
 	xdgDataHome := os.Getenv("XDG_DATA_HOME")
 	if xdgDataHome != "" {
-		saveFolder = filepath.Join(xdgDataHome, "saves")
-		return
+		return filepath.Join(xdgDataHome, "saves"), nil
 	}
 
 	home, err := os.UserHomeDir()
 	if err != nil {
-		slog.Error("Failed to get user home folder", "err", err)
-		return
+		return "", err
+	}
+	return filepath.Join(home, ".config", appName, "saves"), nil
+}
+
+func loadSettingsFileLocation() (string, error) {
+	xdgConfigHome := os.Getenv("XDG_CONFIG_HOME")
+	if xdgConfigHome != "" {
+		return filepath.Join(xdgConfigHome, settingsFilename), nil
 	}
 
-	saveFolder = filepath.Join(home, ".config", appName, "saves")
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".config", appName, settingsFilename), nil
 }

--- a/pkg/app/locations/locations_linux_test.go
+++ b/pkg/app/locations/locations_linux_test.go
@@ -3,8 +3,6 @@
 package locations
 
 import (
-	"log/slog"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -14,17 +12,25 @@ import (
 func TestLoadSaveFolderLocation(t *testing.T) {
 	assert := assert.New(t)
 
-	home, err := os.UserHomeDir()
-	if err != nil {
-		slog.Error("Failed to get user home folder", "err", err)
-		return
-	}
-
-	expectedFolder := filepath.Join(home, ".config", appName, "saves")
-
-	assert.Equal(expectedFolder, saveFolder, "Variable should have been initialized")
+	path, err := loadSaveFolderLocation()
+	assert.NoError(err)
+	assert.Contains(path, filepath.Join(".config", appName, "saves"), "Variable should have home location ending")
 
 	t.Setenv("XDG_DATA_HOME", "test")
-	loadSaveFolderLocation()
-	assert.Equal("test/saves", saveFolder, "Should read data location from env variable")
+	path, err = loadSaveFolderLocation()
+	assert.NoError(err)
+	assert.Equal("test/saves", path, "Should read data location from env variable")
+}
+
+func TestLoadSettingsFileLocation(t *testing.T) {
+	assert := assert.New(t)
+
+	path, err := loadSettingsFileLocation()
+	assert.NoError(err)
+	assert.Contains(path, filepath.Join(".config", appName, settingsFilename), "Variable should have home location ending")
+
+	t.Setenv("XDG_CONFIG_HOME", "test")
+	path, err = loadSettingsFileLocation()
+	assert.NoError(err)
+	assert.Equal("test/"+settingsFilename, path, "Should read settings.yaml location from env variable")
 }

--- a/pkg/app/locations/locations_test.go
+++ b/pkg/app/locations/locations_test.go
@@ -1,0 +1,55 @@
+package locations
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSaveFolder(t *testing.T) {
+	assert := assert.New(t)
+
+	assert.Empty(saveFolder, "Should not initialize variable")
+
+	t.Cleanup(func() {
+		saveFolder = ""
+	})
+
+	path, err := SaveFolder()
+	assert.NoError(err)
+	assert.Equal(path, saveFolder, "Should cache path in global variable")
+	assert.NotEmpty(path, "Should return a path")
+	_, err = os.Stat(path)
+	assert.NoError(err, "Folder should already exist or be created")
+
+	saveFolder = "not-the-value"
+	path, err = SaveFolder()
+	assert.NoError(err)
+	assert.Equal(path, saveFolder, "result and global variable should be equal")
+	assert.Equal("not-the-value", path, "Should just return the global variable")
+}
+
+func TestSettingsFile(t *testing.T) {
+	assert := assert.New(t)
+
+	assert.Empty(settingsFile, "Should not initialize variable")
+
+	t.Cleanup(func() {
+		settingsFile = ""
+	})
+
+	path, err := SettingsFile()
+	assert.NoError(err)
+	assert.Equal(path, settingsFile, "Should cache path in global variable")
+	assert.NotEmpty(path, "Should return a path")
+	_, err = os.Stat(filepath.Dir(path))
+	assert.NoError(err, "Folder should already exist or be created")
+
+	settingsFile = "not-the-file"
+	path, err = SettingsFile()
+	assert.NoError(err)
+	assert.Equal(path, settingsFile, "result and global variable should be equal")
+	assert.Equal("not-the-file", path, "Should just return the global variable")
+}

--- a/pkg/app/locations/locations_windows.go
+++ b/pkg/app/locations/locations_windows.go
@@ -3,21 +3,22 @@
 package locations
 
 import (
-	"log/slog"
 	"os"
 	"path/filepath"
 )
 
-func init() {
-	loadSaveFolderLocation()
-}
-
-func loadSaveFolderLocation() {
+func loadSaveFolderLocation() (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
-		slog.Error("Failed to get user home folder", "err", err)
-		return
+		return "", err
 	}
+	return filepath.Join(home, "AppData", "Roaming", appName, "saves"), nil
+}
 
-	saveFolder = filepath.Join(home, "AppData", "Roaming", appName, "saves")
+func loadSettingsFileLocation() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, "AppData", "Roaming", appName, settingsFile), nil
 }

--- a/pkg/app/locations/locations_windows_test.go
+++ b/pkg/app/locations/locations_windows_test.go
@@ -3,13 +3,22 @@
 package locations
 
 import (
-	"strings"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestLoadSaveFolderLocation(t *testing.T) {
-	assert.NotEmpty(t, saveFolder, "Should have initialized save folder")
-	assert.True(t, strings.HasSuffix(saveFolder, "\\saves"), "Should end in folder \"saves\"")
+	assert := assert.New(t)
+	path, err := loadSaveFolderLocation()
+	assert.NoError(err)
+	assert.Contains(path, filepath.Join("AppData", "Roaming", appName, "saves"))
+}
+
+func TestLoadSettingsFileLocation(t *testing.T) {
+	assert := assert.New(t)
+	path, err := loadSettingsFileLocation()
+	assert.NoError(err)
+	assert.Contains(path, filepath.Join("AppData", "Roaming", appName, settingsFilename))
 }

--- a/pkg/app/preferences.go
+++ b/pkg/app/preferences.go
@@ -1,0 +1,104 @@
+package app
+
+import (
+	"os"
+
+	"github.com/heathcliff26/go-minesweeper/pkg/app/locations"
+	"github.com/heathcliff26/go-minesweeper/pkg/minesweeper"
+	"gopkg.in/yaml.v3"
+)
+
+type Preferences struct {
+	DifficultyInt int  `yaml:"difficulty"`
+	AssistedMode  bool `yaml:"assistedMode"`
+	GameAlgorithm int  `yaml:"gameAlgorithm"`
+}
+
+// Only used for testing, as we don't want to touch the actual file that might be on the system.
+var overrideSettingsPath = ""
+
+func defaultPreferences() Preferences {
+	return Preferences{
+		DifficultyInt: DEFAULT_DIFFICULTY,
+		AssistedMode:  false,
+		GameAlgorithm: DEFAULT_GAME_ALGORITHM,
+	}
+}
+
+// Load the preferences from the settings file.
+// Return default values when an error occurs.
+func LoadPreferences() (Preferences, error) {
+	path, err := locations.SettingsFile()
+	if err != nil {
+		return defaultPreferences(), err
+	}
+	if overrideSettingsPath != "" {
+		path = overrideSettingsPath
+	}
+
+	f, err := os.ReadFile(path)
+	if err != nil {
+		return defaultPreferences(), err
+	}
+
+	p := defaultPreferences()
+	err = yaml.Unmarshal(f, &p)
+	if err != nil {
+		return defaultPreferences(), err
+	}
+
+	return p, nil
+}
+
+// Convert the current app state to preferences that can be saved.
+func CreatePreferencesFromApp(app *App) Preferences {
+	difficulty := DEFAULT_DIFFICULTY
+	for i, d := range app.difficulties {
+		if d.Checked {
+			difficulty = i
+			break
+		}
+	}
+
+	gameAlgorithm := DEFAULT_GAME_ALGORITHM
+	for i, algorithm := range app.gameAlgorithms {
+		if algorithm.Checked {
+			gameAlgorithm = i
+			break
+		}
+	}
+
+	return Preferences{
+		DifficultyInt: difficulty,
+		AssistedMode:  app.assistedMode.Checked,
+		GameAlgorithm: gameAlgorithm,
+	}
+}
+
+// Convert the saved difficulty number to an actual difficulty
+func (p Preferences) Difficulty() minesweeper.Difficulty {
+	difficulties := minesweeper.Difficulties()
+
+	if p.DifficultyInt < 0 || p.DifficultyInt >= len(difficulties) {
+		return difficulties[DEFAULT_DIFFICULTY]
+	}
+	return difficulties[p.DifficultyInt]
+}
+
+// Save the preferences to the settings file
+func (p Preferences) Save() error {
+	path, err := locations.SettingsFile()
+	if err != nil {
+		return err
+	}
+	if overrideSettingsPath != "" {
+		path = overrideSettingsPath
+	}
+
+	data, err := yaml.Marshal(&p)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(path, data, 0644)
+}

--- a/pkg/app/preferences_test.go
+++ b/pkg/app/preferences_test.go
@@ -1,0 +1,120 @@
+package app
+
+import (
+	"os"
+	"testing"
+
+	"fyne.io/fyne/v2/test"
+	"github.com/heathcliff26/go-minesweeper/pkg/minesweeper"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoadPreferences(t *testing.T) {
+	assert := assert.New(t)
+
+	overrideSettingsPath = "testdata/not-a-file.yaml"
+	t.Cleanup(func() {
+		overrideSettingsPath = ""
+	})
+
+	p, err := LoadPreferences()
+	assert.Error(err)
+	assert.Equal(defaultPreferences(), p, "Should return the default settings when none found")
+
+	overrideSettingsPath = "testdata/settings.yaml"
+	p, err = LoadPreferences()
+	assert.NoError(err)
+	res := Preferences{
+		DifficultyInt: 0,
+		AssistedMode:  true,
+		GameAlgorithm: 0,
+	}
+	assert.Equal(res, p, "Should load the settings")
+
+	overrideSettingsPath = "testdata/not-a-yaml-file.txt"
+	p, err = LoadPreferences()
+	assert.Error(err)
+	assert.Equal(defaultPreferences(), p, "Should return the default settings on error")
+}
+
+func TestCreatePreferencesFromApp(t *testing.T) {
+	newApp = test.NewApp
+
+	a := New()
+
+	for i := range a.difficulties {
+		a.difficulties[i].Checked = i == 0
+	}
+	for i := range a.gameAlgorithms {
+		a.gameAlgorithms[i].Checked = i == 0
+	}
+	a.assistedMode.Checked = true
+
+	p := CreatePreferencesFromApp(a)
+
+	assert := assert.New(t)
+
+	res := Preferences{
+		DifficultyInt: 0,
+		AssistedMode:  true,
+		GameAlgorithm: 0,
+	}
+	assert.Equal(res, p, "Should create the Preferences correctly")
+
+	for i := range a.difficulties {
+		a.difficulties[i].Checked = false
+	}
+	for i := range a.gameAlgorithms {
+		a.gameAlgorithms[i].Checked = false
+	}
+	a.assistedMode.Checked = false
+
+	p = CreatePreferencesFromApp(a)
+	assert.Equal(defaultPreferences(), p, "Should use defaults if not possible")
+}
+
+func TestPreferencesDifficuly(t *testing.T) {
+	assert := assert.New(t)
+
+	p := Preferences{
+		DifficultyInt: minesweeper.DifficultyClassic,
+	}
+	assert.Equal(minesweeper.Difficulties()[minesweeper.DifficultyClassic], p.Difficulty(), "Should return the correct difficulty")
+
+	p.DifficultyInt = minesweeper.DifficultyExpert
+	assert.Equal(minesweeper.Difficulties()[minesweeper.DifficultyExpert], p.Difficulty(), "Should return the correct difficulty")
+
+	p.DifficultyInt = -1
+	assert.Equal(minesweeper.Difficulties()[DEFAULT_DIFFICULTY], p.Difficulty(), "Should return the default difficulty if out of bounds")
+	p.DifficultyInt = minesweeper.DifficultyExpert + 1
+	assert.Equal(minesweeper.Difficulties()[DEFAULT_DIFFICULTY], p.Difficulty(), "Should return the default difficulty if out of bounds")
+}
+
+func TestPreferencesSave(t *testing.T) {
+	p := Preferences{
+		DifficultyInt: 0,
+		AssistedMode:  true,
+		GameAlgorithm: 0,
+	}
+
+	testFilePath := "test-settings.yaml"
+
+	overrideSettingsPath = testFilePath
+	t.Cleanup(func() {
+		overrideSettingsPath = ""
+	})
+
+	assert := assert.New(t)
+
+	err := p.Save()
+	if !assert.NoError(err, "Should save the preferences") {
+		t.FailNow()
+	}
+	t.Cleanup(func() {
+		_ = os.Remove(testFilePath)
+	})
+
+	res, err := LoadPreferences()
+	assert.NoError(err, "Should load the preferences without error")
+	assert.Equal(p, res, "Should load the same preferences it just saved")
+}

--- a/pkg/app/testdata/not-a-yaml-file.txt
+++ b/pkg/app/testdata/not-a-yaml-file.txt
@@ -1,0 +1,1 @@
+This is not a yaml file

--- a/pkg/app/testdata/settings.yaml
+++ b/pkg/app/testdata/settings.yaml
@@ -1,0 +1,3 @@
+difficulty: 0
+assistedMode: true
+gameAlgorithm: 0

--- a/pkg/app/tile_race_test.go
+++ b/pkg/app/tile_race_test.go
@@ -2,10 +2,14 @@
 
 package app
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/heathcliff26/go-minesweeper/pkg/minesweeper"
+)
 
 func TestTileFlagRace(t *testing.T) {
-	g := NewMinesweeperGrid(DEFAULT_DIFFICULTY, false)
+	g := NewMinesweeperGrid(minesweeper.Difficulties()[DEFAULT_DIFFICULTY], false)
 	tile := g.Tiles[0][0]
 	tile.CreateRenderer()
 

--- a/pkg/app/tile_test.go
+++ b/pkg/app/tile_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestNewTile(t *testing.T) {
-	g := NewMinesweeperGrid(DEFAULT_DIFFICULTY, false)
+	g := NewMinesweeperGrid(minesweeper.Difficulties()[DEFAULT_DIFFICULTY], false)
 	tile := g.Tiles[1][2]
 
 	t.Run("New", func(t *testing.T) {
@@ -51,7 +51,7 @@ func TestTileTapped(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
 
-	g := NewMinesweeperGrid(DEFAULT_DIFFICULTY, false)
+	g := NewMinesweeperGrid(minesweeper.Difficulties()[DEFAULT_DIFFICULTY], false)
 	for _, row := range g.Tiles {
 		for _, tile := range row {
 			tile.CreateRenderer()
@@ -78,7 +78,7 @@ func TestTileTappedSecondary(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
 
-	g := NewMinesweeperGrid(DEFAULT_DIFFICULTY, false)
+	g := NewMinesweeperGrid(minesweeper.Difficulties()[DEFAULT_DIFFICULTY], false)
 	tile := g.Tiles[1][2]
 	tile.CreateRenderer()
 
@@ -133,7 +133,7 @@ func TestDoubleTapped(t *testing.T) {
 		t.Run(tCase.Name, func(t *testing.T) {
 			t.Parallel()
 
-			g := NewMinesweeperGrid(DEFAULT_DIFFICULTY, false)
+			g := NewMinesweeperGrid(minesweeper.Difficulties()[DEFAULT_DIFFICULTY], false)
 			for _, row := range g.Tiles {
 				for _, tile := range row {
 					tile.CreateRenderer()
@@ -208,7 +208,7 @@ func TestDoubleTapped(t *testing.T) {
 }
 
 func TestTileUpdateContent(t *testing.T) {
-	g := NewMinesweeperGrid(DEFAULT_DIFFICULTY, false)
+	g := NewMinesweeperGrid(minesweeper.Difficulties()[DEFAULT_DIFFICULTY], false)
 	tile := g.Tiles[1][2]
 	tile.CreateRenderer()
 
@@ -343,7 +343,7 @@ func TestTileUpdateContent(t *testing.T) {
 }
 
 func TestTileReset(t *testing.T) {
-	g := NewMinesweeperGrid(DEFAULT_DIFFICULTY, false)
+	g := NewMinesweeperGrid(minesweeper.Difficulties()[DEFAULT_DIFFICULTY], false)
 	tile := g.Tiles[1][2]
 	tile.CreateRenderer()
 
@@ -377,7 +377,7 @@ func TestTileReset(t *testing.T) {
 func TestTileUntappable(t *testing.T) {
 	t.Parallel()
 
-	g := NewMinesweeperGrid(DEFAULT_DIFFICULTY, false)
+	g := NewMinesweeperGrid(minesweeper.Difficulties()[DEFAULT_DIFFICULTY], false)
 	for _, row := range g.Tiles {
 		for _, tile := range row {
 			tile.CreateRenderer()


### PR DESCRIPTION
Write a settings file to store selected preferences and load them on each new start of the app.
Stop loading the save location during init, instead load it on the first run of the relevant function.