### PR TITLE
windows: Fix wrong settings path

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,16 +26,24 @@ jobs:
   lint:
     uses: heathcliff26/ci/.github/workflows/golang-fyne-lint.yaml@main
 
-  unit-tests:
+  unit-tests-linux:
     uses: heathcliff26/ci/.github/workflows/golang-unit-tests.yaml@main
     with:
       cmd: hack/unit-tests.sh
+      os: ubuntu-latest
+
+  unit-tests-windows:
+    uses: heathcliff26/ci/.github/workflows/golang-unit-tests.yaml@main
+    with:
+      cmd: go test -v -timeout 300s ./...
+      os: windows-latest
 
   build:
     uses: heathcliff26/ci/.github/workflows/golang-fyne-build.yaml@main
     needs:
       - lint
-      - unit-tests
+      - unit-tests-linux
+      - unit-tests-windows
     strategy:
       fail-fast: false
       matrix:

--- a/pkg/app/locations/locations_windows.go
+++ b/pkg/app/locations/locations_windows.go
@@ -20,5 +20,5 @@ func loadSettingsFileLocation() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(home, "AppData", "Roaming", appName, settingsFile), nil
+	return filepath.Join(home, "AppData", "Roaming", appName, settingsFilename), nil
 }


### PR DESCRIPTION
The settings.yaml file would be saved in the wrong location with the wrong name on windows.
Fix the location and enable unit-tests on windows to catch such problems going forward.