### PR TITLE
go.mod: Update dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ coverprofile:
 assets:
 	hack/generate-assets.sh
 
-dependencies:
+update-deps:
 	hack/update-deps.sh
 
 generate:
@@ -41,7 +41,7 @@ clean:
 	lint \
 	coverprofile \
 	assets \
-	dependencies \
+	update-deps \
 	generate \
 	lint-metainfo \
 	clean \

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,11 @@
 module github.com/heathcliff26/go-minesweeper
 
-go 1.22
+go 1.22.0
 
 require (
 	fyne.io/fyne/v2 v2.5.2
 	github.com/stretchr/testify v1.10.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -35,5 +36,4 @@ require (
 	golang.org/x/net v0.25.0 // indirect
 	golang.org/x/sys v0.20.0 // indirect
 	golang.org/x/text v0.16.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
yaml is now directly required.
Run `make update-deps` to rectify.
Fix CodeQL warning by setting full go version.
Rename make command `dependencies` to `update-deps` to be in line with other repositories.