### PR TITLE
Implement custom Theme to make light mode visible

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -1,14 +1,12 @@
 package app
 
 import (
-	"image/color"
 	"log/slog"
 	"os"
 	"time"
 
 	"fyne.io/fyne/v2"
 	fApp "fyne.io/fyne/v2/app"
-	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/container"
 	"fyne.io/fyne/v2/data/binding"
 	"fyne.io/fyne/v2/dialog"
@@ -17,8 +15,6 @@ import (
 	"github.com/heathcliff26/go-minesweeper/pkg/app/locations"
 	"github.com/heathcliff26/go-minesweeper/pkg/minesweeper"
 )
-
-var TEXT_COLOR = color.White
 
 const DEFAULT_DIFFICULTY = minesweeper.DifficultyBeginner
 
@@ -54,6 +50,7 @@ func New() *App {
 	app := newApp()
 	version := getVersion(app)
 	main := app.NewWindow(version.Name)
+	app.Settings().SetTheme(mainTheme{})
 
 	a := &App{
 		app:     app,
@@ -178,14 +175,12 @@ func (a *App) customDifficultyDialog() {
 	mines := minesweeper.DifficultyMineMin
 	row, col := minesweeper.DifficultyRowColMin, minesweeper.DifficultyRowColMin
 
-	mineLabel := canvas.NewText("Mines", TEXT_COLOR)
-	mineEntry := widget.NewEntryWithData(binding.IntToString(binding.BindInt(&mines)))
-	rowLabel := canvas.NewText("Rows", TEXT_COLOR)
-	rowEntry := widget.NewEntryWithData(binding.IntToString(binding.BindInt(&row)))
-	colLabel := canvas.NewText("Columns", TEXT_COLOR)
-	colEntry := widget.NewEntryWithData(binding.IntToString(binding.BindInt(&col)))
+	mineItem := widget.NewFormItem("Mines", widget.NewEntryWithData(binding.IntToString(binding.BindInt(&mines))))
+	rowItem := widget.NewFormItem("Rows", widget.NewEntryWithData(binding.IntToString(binding.BindInt(&row))))
+	colItem := widget.NewFormItem("Columns", widget.NewEntryWithData(binding.IntToString(binding.BindInt(&col))))
 
-	content := container.NewGridWithColumns(2, mineLabel, mineEntry, rowLabel, rowEntry, colLabel, colEntry)
+	content := widget.NewForm(mineItem, rowItem, colItem)
+
 	diffDialog := dialog.NewCustomConfirm("Custom Difficulty", "ok", "cancel", content, func(ok bool) {
 		if !ok {
 			return

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -29,7 +29,7 @@ func TestApp(t *testing.T) {
 	a := New()
 
 	t.Run("App", func(t *testing.T) {
-		assert.NotEmpty(t, a.app)
+		assert.NotNil(t, a.app)
 	})
 	t.Run("Main", func(t *testing.T) {
 		assert := assert.New(t)

--- a/pkg/app/theme.go
+++ b/pkg/app/theme.go
@@ -1,0 +1,50 @@
+package app
+
+import (
+	"image/color"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/theme"
+)
+
+var (
+	// Ensure there are compile errors if the theme interface is not implemented
+	_ fyne.Theme = mainTheme{}
+	_ fyne.Theme = borderTheme{}
+)
+
+type mainTheme struct{}
+
+func (mainTheme) Color(name fyne.ThemeColorName, variant fyne.ThemeVariant) color.Color {
+	if variant == theme.VariantLight && name == theme.ColorNameBackground {
+		return color.RGBA{211, 211, 211, alpha} // Light Gray
+	}
+	return theme.DefaultTheme().Color(name, variant)
+}
+
+func (mainTheme) Font(style fyne.TextStyle) fyne.Resource {
+	return theme.DefaultTheme().Font(style)
+}
+
+func (mainTheme) Icon(name fyne.ThemeIconName) fyne.Resource {
+	return theme.DefaultTheme().Icon(name)
+}
+
+func (mainTheme) Size(name fyne.ThemeSizeName) float32 {
+	return theme.DefaultTheme().Size(name)
+}
+
+type borderTheme struct {
+	mainTheme
+}
+
+func (borderTheme) Color(name fyne.ThemeColorName, variant fyne.ThemeVariant) color.Color {
+	if name == theme.ColorNameShadow {
+		if variant == theme.VariantLight {
+			return color.Black
+		} else if variant == theme.VariantDark {
+			return color.White
+		}
+	}
+	return mainTheme{}.Color(name, variant)
+}

--- a/pkg/app/theme_test.go
+++ b/pkg/app/theme_test.go
@@ -1,0 +1,31 @@
+package app
+
+import (
+	"image/color"
+	"testing"
+
+	"fyne.io/fyne/v2/theme"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMainTheme(t *testing.T) {
+	assert := assert.New(t)
+
+	assert.Equal(color.RGBA{211, 211, 211, alpha}, mainTheme{}.Color(theme.ColorNameBackground, theme.VariantLight))
+	assert.Equal(theme.DefaultTheme().Color(theme.ColorNameBackground, theme.VariantDark), mainTheme{}.Color(theme.ColorNameBackground, theme.VariantDark))
+
+	assert.Equal(theme.DefaultTheme().Icon(theme.IconNameAccount), mainTheme{}.Icon(theme.IconNameAccount))
+	assert.Equal(theme.DefaultTheme().Size(theme.SizeNameSeparatorThickness), mainTheme{}.Size(theme.SizeNameSeparatorThickness))
+}
+
+func TestBorderTheme(t *testing.T) {
+	assert := assert.New(t)
+
+	assert.Equal(color.Black, borderTheme{}.Color(theme.ColorNameShadow, theme.VariantLight))
+	assert.Equal(color.White, borderTheme{}.Color(theme.ColorNameShadow, theme.VariantDark))
+
+	assert.Equal(mainTheme{}.Color(theme.ColorNameBackground, theme.VariantLight), borderTheme{}.Color(theme.ColorNameBackground, theme.VariantLight))
+	assert.Equal(mainTheme{}.Color(theme.ColorNameBackground, theme.VariantDark), borderTheme{}.Color(theme.ColorNameBackground, theme.VariantDark))
+	assert.Equal(mainTheme{}.Icon(theme.IconNameAccount), borderTheme{}.Icon(theme.IconNameAccount))
+	assert.Equal(mainTheme{}.Size(theme.SizeNameSeparatorThickness), borderTheme{}.Size(theme.SizeNameSeparatorThickness))
+}

--- a/pkg/app/utils.go
+++ b/pkg/app/utils.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"image/color"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -11,6 +10,7 @@ import (
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/widget"
 )
 
 // Struct for containing the current version of the app
@@ -49,36 +49,39 @@ func getVersion(app fyne.App) Version {
 
 // Create the content for the version dialog
 func getVersionContent(v Version) fyne.CanvasObject {
-	r1 := make([]fyne.CanvasObject, 3)
-	r2 := make([]fyne.CanvasObject, 3)
-	r1[0] = canvas.NewText("Version:", TEXT_COLOR)
-	r2[0] = canvas.NewText(v.Version, TEXT_COLOR)
-	r1[1] = canvas.NewText("Commit:", TEXT_COLOR)
-	r2[1] = canvas.NewText(v.Commit, TEXT_COLOR)
-	r1[2] = canvas.NewText("Go:", TEXT_COLOR)
-	r2[2] = canvas.NewText(v.Go, TEXT_COLOR)
+	data := [][]string{
+		{"Version:", v.Version},
+		{"Commit:", v.Commit},
+		{"Go:", v.Go},
+	}
 
-	row1 := container.NewVBox(r1...)
-	row2 := container.NewVBox(r2...)
+	versionTable := widget.NewTable(
+		func() (int, int) {
+			return len(data), len(data[0])
+		},
+		func() fyne.CanvasObject {
+			return widget.NewLabel("                ")
+		},
+		func(i widget.TableCellID, o fyne.CanvasObject) {
+			o.(*widget.Label).SetText(data[i.Row][i.Col])
+		},
+	)
 
-	return container.NewPadded(container.NewHBox(row1, row2))
-}
+	versionTable.ShowHeaderRow = false
+	versionTable.ShowHeaderColumn = false
+	versionTable.StickyRowCount = len(data) - 1
+	versionTable.StickyColumnCount = len(data[0]) - 1
+	versionTable.HideSeparators = true
 
-// Create a line for the border
-func makeBorderStrip() fyne.CanvasObject {
-	rec := canvas.NewRectangle(color.White)
-	rec.SetMinSize(fyne.NewSize(1, 1))
-	return rec
+	return versionTable
 }
 
 // Wrap the objects in a box with border lines
 func newBorder(content ...fyne.CanvasObject) fyne.CanvasObject {
-	top := makeBorderStrip()
-	left := makeBorderStrip()
-	bottom := makeBorderStrip()
-	right := makeBorderStrip()
-	border := container.NewBorder(top, bottom, left, right, content...)
-	return container.NewPadded(border)
+	contentContainer := container.NewThemeOverride(container.NewPadded(content...), mainTheme{})
+	border := widget.NewCard("", "", contentContainer)
+
+	return container.NewThemeOverride(border, borderTheme{})
 }
 
 // Create a new label used in the grid, with preset color, text size and text style


### PR DESCRIPTION
Use a custom theme to enable users to use light mode. Switch multiple elements from basic canvas to widget, so that they use the theme instead of static colors.