### PR TITLE
go.mod: Raise required go version to 1.24

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/heathcliff26/go-minesweeper
 
-go 1.22.0
+go 1.24.0
 
 require (
 	fyne.io/fyne/v2 v2.5.4


### PR DESCRIPTION
Since go 1.22 is deprecated, raise the required go version to latest version.