### PR TITLE
CI: Speedup total CI time by running builds sooner

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,8 +65,7 @@ jobs:
       contents: read
     needs:
       - lint
-      - unit-tests-linux
-      - unit-tests-windows
+      - validate
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Since the builds are binaries and merely cached, it does not matter if the
builds start running before the unit-tests are finished.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>