### PR TITLE
tests: Improve flaky timer tests

### DIFF
--- a/pkg/app/timer_test.go
+++ b/pkg/app/timer_test.go
@@ -27,10 +27,8 @@ func TestTimer(t *testing.T) {
 		timer.Start()
 		assert.True(timer.running)
 
-		time.Sleep(10 * time.Second)
+		time.Sleep(10*time.Second + 500*time.Millisecond)
 		timer.Stop()
-		// Wait extra to ensure updates finished
-		time.Sleep(time.Second)
 
 		assert.False(timer.running)
 		assert.Equal(10, timer.Seconds)
@@ -63,10 +61,8 @@ func TestTimer(t *testing.T) {
 		timer.Start()
 		assert.True(timer.running)
 
-		time.Sleep(10 * time.Second)
+		time.Sleep(10*time.Second + 500*time.Millisecond)
 		timer.Stop()
-		// Wait extra to ensure updates finished
-		time.Sleep(time.Second)
 
 		assert.Equal(10, timer.Seconds)
 	})


### PR DESCRIPTION
Tweak the timings a bit to ensure that the timer tests do not flake.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>