### PR TITLE
app: Remove empty file generated by fyne save file dialog

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"log/slog"
+	"os"
 	"time"
 
 	"fyne.io/fyne/v2"
@@ -252,6 +253,14 @@ func (a *App) saveGameCallback(path string, err error) {
 		return
 	}
 	if path == "" {
+		return
+	}
+
+	// Ensure that empty files created by fynes file dialog are removed before creating the save.
+	// This ensures that no empty files without ".sav" extension are created.
+	err = os.Remove(path)
+	if err != nil && !os.IsNotExist(err) {
+		dialog.ShowError(err, a.main)
 		return
 	}
 

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -198,6 +198,19 @@ func TestSaveGame(t *testing.T) {
 		_, err := minesweeper.LoadSave(savePath)
 		assert.NoError(err, "Should be able to load the save file")
 	})
+
+	t.Run("RemoveEmptyFileCreatedByFyneFileDialog", func(t *testing.T) {
+		assert := assert.New(t)
+
+		savePath := filepath.Join(dir, "empty-file")
+
+		require.NoError(t, os.WriteFile(savePath, []byte(""), 0644), "Should create an empty file")
+
+		a.saveGameCallback(savePath, nil)
+
+		assert.FileExists(savePath+".sav", "Save file should exist")
+		assert.NoFileExists(savePath, "Empty file should be removed")
+	})
 }
 
 func TestLoadSave(t *testing.T) {


### PR DESCRIPTION
When using fyne's save file dialog, an empty file is created. Since the save
implementation might add the file extension to the path, this file could end
up being left over.
Ensure it get's removed before writing the actual save file.

Example for previous behavior:
1. User selects "awesome-game" as the new save file.
2. Fyne creates an empty file "awesome-game" as part of the dialog.
3. The save get's written to "awesome-game.sav".
4. The empty file "awesome-game" is left over.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>