### PR TITLE
unit-tests: Increase timeout to 7min

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ lint:
 
 # Run unit-tests
 test:
-	go test -v -race -timeout 300s -coverprofile=coverprofile.out -coverpkg "./pkg/..." ./...
+	go test -v -race -timeout 420s -coverprofile=coverprofile.out -coverpkg "./pkg/..." ./...
 
 # Build the project with optional GOOS and GOARCH
 build:


### PR DESCRIPTION
Running with coverprofile makes the run take longer. Currently it runs into timeouts.
Not sure why that happens, might be the newer golang version 1.24.3.