### PR TITLE
Improve order of execution when resetting grid

### DIFF
--- a/pkg/app/grid.go
+++ b/pkg/app/grid.go
@@ -280,38 +280,31 @@ func (g *MinesweeperGrid) Col() int {
 
 // Start a new game
 func (g *MinesweeperGrid) NewGame() {
-	// Ensure that the game lock is released before calling reset.
-	// This ensures that no deadlock occurs when autosolve is running.
-	func() {
-		g.lGame.Lock()
-		defer g.lGame.Unlock()
+	g.reset()
 
-		slog.Info("Preparing for new game")
-		g.Game = nil
-		g.solver = nil
-	}()
-	g.Reset()
+	g.lGame.Lock()
+	defer g.lGame.Unlock()
+
+	slog.Info("Preparing for new game")
+	g.Game = nil
+	g.solver = nil
 }
 
 // Replay the current game
 func (g *MinesweeperGrid) Replay() {
-	// Ensure that the game lock is released before calling reset.
-	// This ensures that no deadlock occurs when autosolve is running.
-	func() {
-		g.lGame.Lock()
-		defer g.lGame.Unlock()
+	g.reset()
 
-		slog.Info("Preparing for replay of current game")
-		if g.Game != nil {
-			g.Game.Replay()
-		}
-	}()
+	g.lGame.Lock()
+	defer g.lGame.Unlock()
 
-	g.Reset()
+	slog.Info("Preparing for replay of current game")
+	if g.Game != nil {
+		g.Game.Replay()
+	}
 }
 
 // Reset Grid
-func (g *MinesweeperGrid) Reset() {
+func (g *MinesweeperGrid) reset() {
 	g.lAutosolve.Lock()
 	defer g.lAutosolve.Unlock()
 

--- a/pkg/app/grid_test.go
+++ b/pkg/app/grid_test.go
@@ -470,9 +470,6 @@ func TestAutosolve(t *testing.T) {
 		{"Replay", func(g *MinesweeperGrid) {
 			g.Replay()
 		}},
-		{"Reset", func(g *MinesweeperGrid) {
-			g.Reset()
-		}},
 	}
 
 	for _, tCase := range tMatrix2 {


### PR DESCRIPTION
Call reset first to ensure that autosolve is stopped before making changes to
the game.
Additionally make the grid reset function private, as it is not needed outside
of the package.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>