### PR TITLE
game: Speed up unit test by not testing all difficulties with NewGameSolvable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ lint:
 
 # Run unit-tests
 test:
-	go test -v -race -timeout 420s -coverprofile=coverprofile.out -coverpkg "./pkg/..." ./...
+	go test -v -race -timeout 300s -coverprofile=coverprofile.out -coverpkg "./pkg/..." ./...
 
 # Build the project with optional GOOS and GOARCH
 build:

--- a/pkg/minesweeper/game_test.go
+++ b/pkg/minesweeper/game_test.go
@@ -85,13 +85,7 @@ func TestNewGameWithSafeArea(t *testing.T) {
 }
 
 func TestNewGameSolvable(t *testing.T) {
-	tMatrix := Difficulties()
-	tMatrix = append(tMatrix, Difficulty{
-		Name:  "InvertedExpert",
-		Row:   30,
-		Col:   16,
-		Mines: 99,
-	})
+	tMatrix := Difficulties()[:3]
 	p := NewPos(1, 1)
 
 	for _, d := range tMatrix {


### PR DESCRIPTION
We do not gain additionall coverage by testing all difficulties. On the other
side we do run into timeouts since Expert difficulty takes significantly more
time.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>