### PR TITLE
metainfo: Validate metainfo with appstream instead of via flatpak

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,10 @@ fmt:
 validate:
 	hack/validate.sh
 
+# Validate the appstream metainfo file
+validate-metainfo:
+	appstreamcli validate io.github.heathcliff26.go-minesweeper.metainfo.xml
+
 # Generate assets for the project
 assets:
 	hack/generate-assets.sh
@@ -44,10 +48,6 @@ update-deps:
 # Run Go generate for the project
 generate:
 	go generate ./...
-
-# Lint the metainfo file for Flatpak
-lint-metainfo:
-	flatpak run --command=flatpak-builder-lint org.flatpak.Builder appstream io.github.heathcliff26.go-minesweeper.metainfo.xml
 
 # Scan code for vulnerabilities using gosec
 gosec:
@@ -73,10 +73,10 @@ help:
 	coverprofile \
 	fmt \
 	validate \
+	validate-metainfo \
 	assets \
 	update-deps \
 	generate \
-	lint-metainfo \
 	gosec \
 	clean \
 	help \

--- a/hack/validate.sh
+++ b/hack/validate.sh
@@ -19,3 +19,6 @@ if [ $rc -ne 0 ]; then
     echo "FATAL: Need to run \"make assets\""
     exit 1
 fi
+
+echo "Check if metainfo file is valid"
+make validate-metainfo


### PR DESCRIPTION
Validate the metainfo file in CI using appstreamcli.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>