### PR TITLE
metainfo: Change license to Apache-2.0

### DIFF
--- a/io.github.heathcliff26.go-minesweeper.metainfo.xml
+++ b/io.github.heathcliff26.go-minesweeper.metainfo.xml
@@ -6,7 +6,7 @@
     <summary>A minesweeper game</summary>
 
     <metadata_license>MIT</metadata_license>
-    <project_license>Artistic-2.0</project_license>
+    <project_license>Apache-2.0</project_license>
 
     <description>
         <p>


### PR DESCRIPTION
The licenses mentioned in the file are copied from the template.
It should therefore not differen from LICENSE.