### PR TITLE
Fix missing icon in dash on linux

### DIFF
--- a/packages/io.github.heathcliff26.go-minesweeper.desktop
+++ b/packages/io.github.heathcliff26.go-minesweeper.desktop
@@ -9,3 +9,4 @@ Keywords=minesweeper;
 Icon=io.github.heathcliff26.go-minesweeper
 Exec=go-minesweeper
 Terminal=false
+StartupWMClass=go-minesweeper


### PR DESCRIPTION
Add StartupWMClass to fix missing icon in dash.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>