### PR TITLE
pkg/minesweeper: Fix panic when running solver without game

### DIFF
--- a/io.github.heathcliff26.go-minesweeper.metainfo.xml
+++ b/io.github.heathcliff26.go-minesweeper.metainfo.xml
@@ -74,6 +74,7 @@
         <release version="v0.9.4" date="2025-11-01" type="stable">
             <description>
                 <p>Bumped framework version</p>
+                <p>Fixed potential crash when starting a new game while autosolve is running.</p>
             </description>
             <url type="details">https://github.com/heathcliff26/go-minesweeper/releases/tag/v0.9.4</url>
         </release>

--- a/pkg/app/grid_test.go
+++ b/pkg/app/grid_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"runtime"
 	"testing"
 	"time"
 
@@ -474,6 +475,10 @@ func TestAutosolve(t *testing.T) {
 
 	for _, tCase := range tMatrix2 {
 		t.Run("QuitOn"+tCase.Name, func(t *testing.T) {
+			if tCase.Name != "NewGame" && runtime.GOOS == "windows" {
+				t.Skip("Skipping as the test follows a weird path on Windows, see https://github.com/heathcliff26/go-minesweeper/issues/228")
+			}
+
 			t.Parallel()
 			require := require.New(t)
 
@@ -540,8 +545,8 @@ func TestAutosolve(t *testing.T) {
 		}
 		g.TappedTile(minesweeper.NewPos(0, 0))
 
-		g.autosolveBreak = make(chan bool, 1)
-		g.autosolveDone = make(chan bool, 1)
+		g.autosolveBreak = make(chan struct{}, 1)
+		g.autosolveDone = make(chan struct{}, 1)
 
 		assert.False(g.Autosolve(0), "Should not run autosolve")
 	})

--- a/pkg/minesweeper/solver.go
+++ b/pkg/minesweeper/solver.go
@@ -17,7 +17,9 @@ type Solver struct {
 
 func NewSolver(g Game) *Solver {
 	return &Solver{
-		game: g,
+		game:      g,
+		nextSteps: []Pos{},
+		mines:     make([]Pos, 0, 100),
 	}
 }
 
@@ -39,14 +41,16 @@ func (s *Solver) Update() {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
+	// This should not happen, but can happen in grid if Autosolve is called at the same time as NewGame.
+	if s.game == nil {
+		return
+	}
+
 	status := s.game.Status()
 	if status == nil || status.GameOver() || status.GameWon() {
 		return
 	}
 
-	if s.mines == nil {
-		s.mines = make([]Pos, 0, s.game.Difficulty().Mines)
-	}
 	nextSteps := make([]Pos, 0, 25)
 	for _, p := range s.nextSteps {
 		if !status.Field[p.X][p.Y].Checked {

--- a/pkg/minesweeper/solver_test.go
+++ b/pkg/minesweeper/solver_test.go
@@ -11,6 +11,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestNewSolver(t *testing.T) {
+	assert := assert.New(t)
+
+	game := NewGameWithSafePos(Difficulties()[0], NewPos(0, 0))
+	solver := NewSolver(game)
+	assert.NotNil(solver, "Solver should not be nil")
+	assert.NotNil(solver.mines, "Mines slice should not be nil")
+	assert.NotNil(solver.nextSteps, "Next steps slice should not be nil")
+	assert.Equal(game, solver.game, "Solver should contain reference to the game")
+}
+
 func TestSolverAutosolve(t *testing.T) {
 	for i := 1; i < 6; i++ {
 		t.Run("Solvable-"+strconv.Itoa(i), func(t *testing.T) {
@@ -137,4 +148,10 @@ func TestSolverUpdateEarlyReturn(t *testing.T) {
 			assert.Empty(s.nextSteps, "nextSteps should be empty")
 		})
 	}
+	t.Run("GameIsNil", func(t *testing.T) {
+		s := &Solver{}
+		assert.NotPanics(t, func() {
+			s.Update()
+		}, "Update should not panic when game is nil")
+	})
 }


### PR DESCRIPTION
If the timing is wrong, a solver without a game can be created.
As it will be immediatly obsolete, make Update() a noop instead of letting it panic.

Fixes: #228

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>